### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,8 +14,8 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.2
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x" # currently 3.6.6
       PYTHON_ARCH: "32"
 
    #- PYTHON: "C:\\Python35-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: python
 python:
    # These jobs are only used in testing, no packaging done and are currently allowed failures
- - 3.6
  - nightly
 
 env:
@@ -16,7 +15,7 @@ matrix:
   include:
      # This is the job that will be used when building packages for Linux
    - os: linux
-     python: 3.5
+     python: 3.6
      env:
       - DEPLOY=true
       - TRAVIS_NODE_VERSION="8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,10 @@ matrix:
    - osx_image: xcode9
 
 before_install:
+ # Install Python 3.6.5
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
      brew update;
-     brew upgrade python;
+     brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb;
      brew install findutils;
      export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH";
    fi


### PR DESCRIPTION
Goes a bit further than #223...

The only thing that ever held us back was PyInstaller, which got 3.6 support a long time ago.