### PR TITLE
Fixed 1 issue of type: PYTHON_F401 throughout 1 file in repo.

### DIFF
--- a/scripts/logcrawler.py
+++ b/scripts/logcrawler.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import datetime, date, time
+from datetime import datetime
 from collections import defaultdict
 import logging
 


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        