### PR TITLE
fixed issues with PyInstaller multipackaging by moving modules t…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,13 @@ package:
 	mkdir -p dist/activitywatch
 #
 	make --directory=aw-watcher-afk package
-	cp -r aw-watcher-afk/dist/aw-watcher-afk/. dist/activitywatch
+	cp -r aw-watcher-afk/dist/aw-watcher-afk dist/activitywatch
 #
 	make --directory=aw-watcher-window package
-	cp -r aw-watcher-window/dist/aw-watcher-window/. dist/activitywatch
+	cp -r aw-watcher-window/dist/aw-watcher-window dist/activitywatch
 #
 	make --directory=aw-server package
-	cp -r aw-server/dist/aw-server/. dist/activitywatch
+	cp -r aw-server/dist/aw-server dist/activitywatch
 #
 	make --directory=aw-qt package
 	cp -r aw-qt/dist/aw-qt/. dist/activitywatch

--- a/scripts/package/activitywatch-setup.iss
+++ b/scripts/package/activitywatch-setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "ActivityWatch"
-#define MyAppVersion "v0.8.0b9"
+#define MyAppVersion GetEnv('AW_VERSION')
 #define MyAppPublisher "ActivityWatch Contributors"
 #define MyAppURL "https://activitywatch.net/"
 #define MyAppExeName "aw-qt.exe"

--- a/scripts/package/activitywatch-setup.iss
+++ b/scripts/package/activitywatch-setup.iss
@@ -54,3 +54,7 @@ Name: "{userstartup}\(#MyAppName)"; Filename: "{app}\{#MyAppExeName}"; Tasks: St
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
+; Removes the previously installed version before installing the new one
+; NOTE: Doesn't work? And also discouraged by the docs
+;[InstallDelete]
+;Type: filesandordirs; Name: "{app}\"

--- a/scripts/package/package-all.sh
+++ b/scripts/package/package-all.sh
@@ -72,7 +72,7 @@ function build_setup() {
 
     choco install -y innosetup
 
-    "/c/Program Files (x86)/Inno Setup 6/iscc.exe" scripts/package/activitywatch-setup.iss
+    env AW_VERSION=$version "/c/Program Files (x86)/Inno Setup 6/iscc.exe" scripts/package/activitywatch-setup.iss
     mv dist/activitywatch-setup.exe dist/$filename
     echo "Setup built!"
 }


### PR DESCRIPTION
As it turns out, the broken multipackage/MERGE feature of PyInstaller was broken for very good reason (https://github.com/pyinstaller/pyinstaller/issues/1527): copy-merging multiple PyInstaller output directories led to segfaults or import errors for 3 out of 4 modules (aw-qt, aw-watcher-web, aw-watcher-afk) on Windows.

It's worth noting that we did not have this problem before upgrading to the newer PyInstaller in our Windows CI (#309).

I think I've fixed it now by moving the modules (aw-server, aw-watcher-web, aw-watcher-afk) to subdirectories and leaving aw-qt in the root directory. It took a minor change to aw-qt to look for the executables in the right place, but it appears to be working now.

I also fixed the Windows installer, which before required manually editing the version number before every release (now set automatically from the tag name).
