### PR TITLE
updated aw-server, attempted travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ before_install:
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
      brew update;
      brew unlink python;
-     brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8de2c2b06a030b9f9a137f16481ed6c84512240c/Formula/python.rb;
+     brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/2efdfe5519df7654ece8d70786baa298e568eafd/Formula/python.rb;
+     brew link python;
      brew install findutils;
      export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH";
      rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION;


### PR DESCRIPTION
 - Attempts to fix the recent Travis errors on the macOS builds by using a newer brew formula to install Python.

The aw-webui upgrade includes:
 - Fixes an annoying bug in aw-webui (#313)
 - Fixes the favicon for aw-webui
 - Adds the filter-by-category feature to the activity view