### PR TITLE
Fix icon in macos .app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ dist/ActivityWatch.dmg: dist/ActivityWatch.app
 
 dist/ActivityWatch.app: aw-qt/media/logo/logo.icns
 	pip install git+git://github.com/pyinstaller/pyinstaller.git@55c8855d9db0fa596ceb28505f3ee2f402ecd4da
-	pyinstaller --clean --noconfirm --windowed aw.spec
+	pyinstaller --clean --noconfirm --windowed -i aw-qt/media/logo/logo.icns aw.spec
 
 package:
 	mkdir -p dist/activitywatch


### PR DESCRIPTION
Thanks to some help (https://github.com/pyinstaller/pyinstaller/issues/4574#issuecomment-583243382 ) from the pyinstaller repo I managed to fix the .app icon. 

Solution was to pass it in the makefile as a command line argument. Weird workaround but it works.