### PR TITLE
Add aw-server-rust binary to pyinstaller bundles 

### DIFF
--- a/aw.spec
+++ b/aw.spec
@@ -10,6 +10,7 @@ aw_core_path = os.path.dirname(aw_core.__file__)
 restx_path = os.path.dirname(flask_restx.__file__)
 
 aws_location = "aw-server/"
+aw_server_rust_bin = "aw-server-rust/target/package/aw-server-rust"
 aw_qt_location = "aw-qt/"
 awa_location = "aw-watcher-afk/"
 aww_location = "aw-watcher-window/"
@@ -50,7 +51,7 @@ aw_server_a = Analysis(['aw-server/__main__.py'],
 
 aw_qt_a = Analysis([aw_qt_location + 'aw_qt/__main__.py'],
                    pathex=[] + extra_pathex,
-                   binaries=None,
+                   binaries=[(aw_server_rust_bin, '.')],
                    datas=[(aw_qt_location + 'resources/aw-qt.desktop', 'aw_qt/resources')],
                    hiddenimports=[],
                    hookspath=[],


### PR DESCRIPTION
Solves the macOS side of #353

Tested this locally and it did work, ready to merge if CI passes. 

Should probably bump version number to something like 0.9 as well.

Also as a note for the future: I locally tried a build without python aw-server at all, and besides aw-qt having the hard coded UI button for "aw-server" it worked fine.