### PR TITLE
Add some dependency caching, fix a couple of travis warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ env:
 services:
  - mongodb
 
-matrix:
+cache:
+  directories:
+    - $HOME/.rustup
+    - $HOME/.cache/pip
+    - aw-server-rust/target
+
+jobs:
   include:
    - os: linux
      python: 3.6
@@ -20,6 +26,9 @@ matrix:
      osx_image: xcode10.1
      language: generic
      python: null
+     cache:
+       directories:
+          - $HOME/Library/Caches/Homebrew
      env:
       - DEPLOY=true
       - TRAVIS_NODE_VERSION=12
@@ -102,7 +111,6 @@ before_deploy:
 
 deploy:
  - provider: releases
-   skip_cleanup: true
    file_glob: true
    file: dist/activitywatch-*.*
    api_key:
@@ -111,12 +119,11 @@ deploy:
      tags: true
      condition: $DEPLOY = true
  - provider: s3
-   skip_cleanup: true
    access_key_id: AKIAIISX5RJFA4X23TTA
    secret_access_key:
      secure: RMrCpX6HsOlRwU3DW8kycQZKvlMy12jGZ2PY6mtyjRAy4S8ddq1FA42KlHnvCRxqwjBp7WBbINoczAiNUfoT62oa8/csSTO2WkD2XxRfIEjrY/NSBrz4lQBnQ9RENez4DBr0HsLSUwWt1ySN1O7cs+RC2Cz/i9+5qpMzU1gQgZYYBB77p4GR/S6HHDIbMO7c9IjhOHQp3p7d4evyvZ9+Oq1uncgKdzl5Qnl/xov6w8F6Yi0Tpe1q1l5UftpQmq6k1PgKQPTIv61r2mWCEAW77LeJaQvJeKY/UfXPecWHS6SriFQqraAtbSokD7juYwiddQ2niJ3q2zLTQBTt5paA+0lYe9Vwv0wQqAThUCnpBfPGTmowTeyW1zkoPLLEGPiRzVlwO6cV5jaModn54Jp210k301SuxS8CG9QbGOLJPplsLWx/+SX225aggpUqYd6YLkqrb/ikPfmrUeaM25ctVz7QoMzM8VuurcVgkNLQKbZvHutVNM056vuZqTKBNUsHwS0CPYwL9R0+z0Kz+7Pm9XS0jtnDl7fUcBUD7EVgimweAodEDrjbweDbvZN+0kiGcSjlARwhIQ1X3zUPqb/R1SfXZOk1/Koe48UScnpWZEFItga1ftF+OfGX7mitzN5FcX7SfBUzSuu0C8zouYRct+zfmfnBbGkOy3igVaGg7oY=
    bucket: activitywatch-builds
-   local-dir: dist
+   local_dir: dist
    acl: public_read
    on:
      condition: $DEPLOY = true


### PR DESCRIPTION
These are the least refactory and most working changes from the travis things I tried today.

Renaming the "matrix", local_dir and removing skip_cleanup is just moving to more recent travis standards, and they don't change the build at all.

These caches should make the build somewhat faster with no real downside. Pip, .rustup and brew caches are fairly safe, and cargo's target should also be faster than recompiling dependencies etc. every time, but it will still rebuild the relevant artifacts if source files have changes.