### PR TITLE
Submodule update with full_test workaround actually in

### DIFF
--- a/aw.spec
+++ b/aw.spec
@@ -195,4 +195,4 @@ if platform.system() == "Darwin":
                  info_plist={"CFBundleExecutable": "MacOS/aw-qt",
                              "CFBundleIconFile": "logo.icns",
                             # TODO: Get the right version here
-                             "CFBundleShortVersionString": "0.8.4"})
+                             "CFBundleShortVersionString": "0.9.0"})


### PR DESCRIPTION
Previous submodule update somehow didn't get the latest aw-server-rust commit (the aw-server-rust hashes did something weird in the merges there). This fixes it and bumps aw.spec version number. Should pass travis.