### PR TITLE
global defines  # declared in the calling script

### DIFF
--- a/scripts/package/dmgbuild-settings.py
+++ b/scripts/package/dmgbuild-settings.py
@@ -13,6 +13,7 @@ import os.path
 
 # .. Useful stuff ..............................................................
 
+global defines  # declared in the calling script
 application = defines.get('app', 'dist/ActivityWatch.app')
 appname = os.path.basename(application)
 


### PR DESCRIPTION
As discussed at https://github.com/ActivityWatch/activitywatch/pull/383#issuecomment-602166735 explicit is better than implicit.