### PR TITLE
Use git describe --tags --abbrev=0 to retrieve current activitywatch version in aw.spec

### DIFF
--- a/aw.spec
+++ b/aw.spec
@@ -3,8 +3,13 @@
 
 import os
 import platform
+import subprocess
 import aw_core
 import flask_restx
+
+git_cmd = "git describe --tags --abbrev=0"
+current_release = subprocess.run(git_cmd.split(" "), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf8").stdout.strip()
+print("bundling activitywatch version " + current_release)
 
 aw_core_path = os.path.dirname(aw_core.__file__)
 restx_path = os.path.dirname(flask_restx.__file__)
@@ -195,4 +200,4 @@ if platform.system() == "Darwin":
                  info_plist={"CFBundleExecutable": "MacOS/aw-qt",
                              "CFBundleIconFile": "logo.icns",
                             # TODO: Get the right version here
-                             "CFBundleShortVersionString": "0.9.0"})
+                             "CFBundleShortVersionString": current_release })


### PR DESCRIPTION
Couldn't really think of a better way to do this. Don't really want to get the version number from aw-server since that makes it harder to build without it in the future.

Fixes #409 

Also adds a TODO comment to improve the macos .app building in the makefile in the future.