### PR TITLE
docs: added missing iOS availablity column

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ We have a plan to address all of these and we're well on our way. See the table 
 ##### Platforms
 <!-- TODO: Replace Platform names with icons  -->
 
-|               | Windows            | macOS              | Linux              | Android            |
-| ------------- |:------------------:|:------------------:|:------------------:|:------------------:|
-| ActivityWatch | :white_check_mark: | :white_check_mark: | :white_check_mark: | [WIP][android]     |
-| Selfspy       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | 
-| ulogme        | :x:                | :white_check_mark: | :white_check_mark: | :x:                |
-| RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | 
+|               | Windows            | macOS              | Linux              | Android            | iOS                |
+| ------------- |:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| ActivityWatch | :white_check_mark: | :white_check_mark: | :white_check_mark: | [WIP][android]     | :x:                |
+| Selfspy       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| ulogme        | :x:                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
+| RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 [android]: https://github.com/ActivityWatch/activitywatch/issues/6
 


### PR DESCRIPTION
Added missing iOS availability column in platform comparison table.
(Since it's a major platform, I thought it's good to have it here)