### PR TITLE
Setup improvements

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,7 @@
+poetry 1.1.6
+nodejs 15.14.0
+rust nightly
+
+# in order for pyinstall to work properly:
+# export PYTHON_CONFIGURE_OPTS="--enable-framework"
+python 3.7.10

--- a/Makefile
+++ b/Makefile
@@ -79,18 +79,6 @@ update-edge:
 	git submodule foreach -v --recursive "echo 'test' $$(pwd); git checkout master; git pull origin master"
 	make build
 
-create-pipenv:
-	# pipenv --python 3.6
-	#pipenv install --skip-lock -r aw-core/requirements.txt
-	#pipenv install --skip-lock -r aw-core/requirements-dev.txt --dev
-	#pipenv install --skip-lock -r aw-server/requirements.txt
-	#pipenv install --skip-lock -r aw-client/requirements.txt
-	#pipenv install --skip-lock -r aw-watcher-afk/requirements.txt
-	pipenv install --skip-lock -r aw-watcher-window/requirements.txt
-	pipenv install --skip-lock -r aw-qt/requirements.txt
-
-
-
 lint:
 	pylint -E \
 		aw-core/aw_core/ \


### PR DESCRIPTION
Two small tweaks I found helpful:

* I use [`asdf`](https://asdf-vm.com/#/) for version management. It's super helpful to specify the tool versions in the repo when using `asdf` and I imagine others are using this vm as well.
* It doesn't look like `pipenv` is used anywhere, looks safe to remove.

Also, unrelated, but is there a reason in the setup guide we don't recommend using `poetry`'s built in venv setup instead of specifying + sourcing the values manually? I rarely use python, so I could be missing something obvious.