### PR TITLE
build(windows): specify name of app in list of installed apps

### DIFF
--- a/scripts/package/activitywatch-setup.iss
+++ b/scripts/package/activitywatch-setup.iss
@@ -30,6 +30,7 @@ PrivilegesRequiredOverridesAllowed=dialog
 OutputDir={#DistDir}
 OutputBaseFilename=activitywatch-setup
 SetupIconFile="{#RootDir}\aw-qt\media\logo\logo.ico"
+UninstallDisplayName={#MyAppName}
 UninstallDisplayIcon={app}\{#MyAppExeName}
 Compression=lzma
 SolidCompression=yes


### PR DESCRIPTION
Closes #637.

I found information about this [here](https://jrsoftware.org/ishelp/index.php?topic=setup_uninstalldisplayname), but I didn't build it myself, since this process took me a lot of time and never finished.