### PR TITLE
ci: skip building aw-server-rust if cargo is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,13 @@ build:
 	make --directory=aw-watcher-window build
 	make --directory=aw-server build SKIP_WEBUI=$(SKIP_WEBUI)
 ifndef SKIP_SERVER_RUST  # Skip building aw-server-rust if SKIP_SERVER_RUST is defined
-	make --directory=aw-server-rust build SKIP_WEBUI=$(SKIP_WEBUI)
+	echo 'Looking for rust...'
+	if (which cargo); then \
+		echo 'Rust found!'; \
+		make --directory=aw-server-rust build SKIP_WEBUI=$(SKIP_WEBUI); \
+	else \
+		echo 'Rust not found, skipping aw-server-rust!'; \
+	fi
 endif
 	make --directory=aw-qt build
 #   The below is needed due to: https://github.com/ActivityWatch/activitywatch/issues/173


### PR DESCRIPTION
This would probably be better done as a preprocessor step or something