### PR TITLE
ci: change use `python` to `python3`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build:
 	make --directory=aw-client build
 	make --directory=aw-core build
 #	Needed to ensure that the server has the correct version set
-	python -c "import aw_server; print(aw_server.__version__)"
+	python3 -c "import aw_server; print(aw_server.__version__)"
 
 
 # Install


### PR DESCRIPTION
May have been what fixed build issue on M1 mac/with poetry
https://github.com/ActivityWatch/activitywatch/issues/433#issuecomment-998992792

@ErikBjare as suggested!