### PR TITLE
fix(dist): move entitlements , `NSAppleEventsUsageDescription`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,9 @@ dist/ActivityWatch.app: aw-qt/media/logo/logo.icns
 	# 2021-06-23: Needs develop branch PyInstaller (has better macOS support, signing, etc)
 	pyinstaller --clean --noconfirm --windowed --codesign-identity 'XM9GC3SUL2' aw.spec
 
+dist/notarize:
+	bash ./scripts/notarize.sh
+
 package:
 	mkdir -p dist/activitywatch
 #

--- a/aw.spec
+++ b/aw.spec
@@ -157,6 +157,7 @@ aww_exe = EXE(
     upx=True,
     console=True,
     codesign_identity=codesign_identity,
+    entitlements_file=entitlements_file,
 )
 aww_coll = COLLECT(
     aww_exe,
@@ -179,6 +180,7 @@ awa_exe = EXE(
     upx=True,
     console=True,
     codesign_identity=codesign_identity,
+    entitlements_file=entitlements_file,
 )
 awa_coll = COLLECT(
     awa_exe,
@@ -202,6 +204,7 @@ aws_exe = EXE(
     upx=True,
     console=True,
     codesign_identity=codesign_identity,
+    entitlements_file=entitlements_file,
 )
 aws_coll = COLLECT(
     aws_exe,
@@ -225,6 +228,7 @@ awq_exe = EXE(
     icon=icon,
     console=False if platform.system() == "Windows" else True,
     codesign_identity=codesign_identity,
+    entitlements_file=entitlements_file,
 )
 awq_coll = COLLECT(
     awq_exe,
@@ -245,14 +249,12 @@ if platform.system() == "Darwin":
         name="ActivityWatch.app",
         icon=icon,
         bundle_identifier="net.activitywatch.ActivityWatch",
-        # Not respected?
-        codesign_identity=codesign_identity,
-        entitlements_file=entitlements_file,
         version=current_release.lstrip('v'),
         info_plist={
             "NSPrincipalClass": "NSApplication",
             "CFBundleExecutable": "MacOS/aw-qt",
-            "CFBundleIconFile": "logo.icns",
+            "CFBundlpaseIconFile": "logo.icns",
+            "NSAppleEventsUsageDescription": "Please grant access to use Apple Events",
             # This could be set to a more specific version string (including the commit id, for example)
             "CFBundleVersion": current_release.lstrip('v'),
             # Replaced by the 'version' kwarg above

--- a/aw.spec
+++ b/aw.spec
@@ -249,7 +249,7 @@ if platform.system() == "Darwin":
         info_plist={
             "NSPrincipalClass": "NSApplication",
             "CFBundleExecutable": "MacOS/aw-qt",
-            "CFBundlpaseIconFile": "logo.icns",
+            "CFBundleIconFile": "logo.icns",
             "NSAppleEventsUsageDescription": "Please grant access to use Apple Events",
             # This could be set to a more specific version string (including the commit id, for example)
             "CFBundleVersion": current_release.lstrip('v'),

--- a/aw.spec
+++ b/aw.spec
@@ -156,7 +156,6 @@ aww_exe = EXE(
     strip=False,
     upx=True,
     console=True,
-    codesign_identity=codesign_identity,
     entitlements_file=entitlements_file,
 )
 aww_coll = COLLECT(
@@ -179,7 +178,6 @@ awa_exe = EXE(
     strip=False,
     upx=True,
     console=True,
-    codesign_identity=codesign_identity,
     entitlements_file=entitlements_file,
 )
 awa_coll = COLLECT(
@@ -203,7 +201,6 @@ aws_exe = EXE(
     strip=False,
     upx=True,
     console=True,
-    codesign_identity=codesign_identity,
     entitlements_file=entitlements_file,
 )
 aws_coll = COLLECT(
@@ -227,7 +224,6 @@ awq_exe = EXE(
     upx=True,
     icon=icon,
     console=False if platform.system() == "Windows" else True,
-    codesign_identity=codesign_identity,
     entitlements_file=entitlements_file,
 )
 awq_coll = COLLECT(

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,6 +1,6 @@
 appleid="<name@domain.com>" # Email address used for Apple ID
 password="<secret_2FA_password>" # See apps-specific password https://support.apple.com/en-us/HT204397
-teamid="<WWDRTeamID>" # Team idenitifer (if single developer, then set to developer identifier)
+teamid="XM9GC3SUL2" # Team idenitifer (if single developer, then set to developer identifier)
 bundleid=net.activitywatch.ActivityWatch # Match aw.spec
 app=dist/ActivityWatch.app
 dmg=dist/ActivityWatch.dmg

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,0 +1,83 @@
+appleid="<name@domain.com>" # Email address used for Apple ID
+password="<secret_2FA_password>" # See apps-specific password https://support.apple.com/en-us/HT204397
+teamid="<WWDRTeamID>" # Team idenitifer (if single developer, then set to developer identifier)
+bundleid=net.activitywatch.ActivityWatch # Match aw.spec
+app=dist/ActivityWatch.app
+dmg=dist/ActivityWatch.dmg
+
+# XCode >= 13 
+run_notarytool() {
+    dist=$1
+    # Setup the credentials for notarization
+    xcrun notarytool store-credentials "ActivityWatchSigner" --apple-id $appleid --team-id $teamid --password $password
+    # Notarize and wait
+    echo "Notarization: starting for $dist"
+    echo "Notarization: in progress for $dist"
+    xcrun notarytool submit $dist --keychain-profile "ActivityWatchSigner" --wait
+}
+
+# XCode < 13 
+run_altool() {
+    dist=$1
+    # Setup the credentials for notarization
+    xcrun altool --store-password-in-keychain-item "ActivityWatchSigner" -u $appleid -p $password
+    # Notarize and wait
+    echo "Notarization: starting for $dist"
+    upload=$(xcrun altool --notarize-app -t osx -f $dist --primary-bundle-id $bundleid -u $appleid --password "@keychain:ActivityWatchSigner")
+    uuid = $(/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" $upload)
+    while true; do 
+        req=$(xcrun altool --notarization-info $uuid -u $username -p $password --output-format xml)
+        status=$(/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" $req)
+        if [ $status != "in progress" ]; then 
+            break
+        else
+            echo "Notarization: in progress for $dist"
+        fi
+        sleep 10
+    done
+}
+
+# Staples the notarization certificate to the executable/bunldle
+run_stapler() {
+    dist=$1
+    xcrun stapler staple $dist
+}
+
+echo 'Detecting availability of notarization tools'
+notarization_method=exit
+# Detect if notarytool is available
+xcrun notarytool >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "+ Found notarytool"
+    notarization_method=run_notarytool
+fi
+# Fallbqck to altool
+output=xcrun altool >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "+ Found altool"
+    notarization_method=run_altool
+fi
+
+if [ $notarization_method = "exit" ]; then
+    echo "- Found no tools, exiting"
+    $notarization_method
+fi
+
+if test -f "$app"; then
+    echo "Notarizing: $app"
+    zip=$app.zip
+    # Turn the app into a zip file that notarization will accept
+    ditto -c -k --keepParent $app $zip
+    $notarization_method $zip
+    run_stapler $app
+else
+    echo "Skipping: $app"
+fi
+
+if test -f "$dmg"; then
+    echo "Notarizing: $dmg"
+    $notarization_method $dmg
+    run_stapler $dmg
+else
+    echo "Skipping: $dmg"
+fi


### PR DESCRIPTION
1. Entitlements file belongs into the `Exe()` not `Bundle()`, ideally each executable gets its own entitlements file (some processes may need more or less permissions than others).
2. `NSAppleEventsUsageDescription` to allow sending Apple Events (Hardened runtime will complain)
3. Notarization script (needs testing!)

TODO:
* Get rid of `scripts/codesign.sh` <- will not be required, better to codesign through `PyInstaller`

If ActivityWatch ships shared libraries that get dynamically loaded then those will also have to be code signed.

cc @ErikBjare please make sure that you've registered `net.activitywatch.ActivityWatch`  as application identifier through the Apple Developer Program (through the website). It's not required for notarization as far as I know, but once you start creating provisioning profiles, you will need to specify that bundle id in the entitlements file and then it will start bricking notarization if you don't have it. So it's just better in general to make sure that you have it registered!

