### PR TITLE
Adding asfd tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,7 @@
+poetry 1.1.12
+nodejs 15.14.0
+rust nightly
+
+# in order for pyinstall to work properly:
+# export PYTHON_CONFIGURE_OPTS="--enable-framework"
+python 3.9.9


### PR DESCRIPTION
This explicitly defines the runtime dependencies
required to compile and develop the application.

If it doesn't feel right to have this in the repo, I can submit
a gitignore change to exclude this file. It's very helpful to have
these versions defined explicitly rather than reading through documentation
to determine what versions are required. Additionally, it looks like asdf
is picking up more community adoption as time goes on.
