### PR TITLE
ci: enable macOS builds to complete when secrets not set

### DIFF
--- a/aw.spec
+++ b/aw.spec
@@ -19,7 +19,8 @@ print("bundling activitywatch version " + current_release)
 
 entitlements_file = Path(".") / "scripts" / "package" / "entitlements.plist"
 codesign_identity = os.environ.get("APPLE_PERSONALID")
-assert codesign_identity, "Environment variable APPLE_PERSONALID not set"
+if codesign_identity is None:
+    print("Environment variable APPLE_PERSONALID not set. Releases won't be signed.")
 
 aw_core_path = Path(os.path.dirname(aw_core.__file__))
 restx_path = Path(os.path.dirname(flask_restx.__file__))


### PR DESCRIPTION
Needed for PR CI runs to get green, etc.