### PR TITLE
ci(distribution): auto-release to winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -10,3 +10,4 @@ jobs:
         with:
           identifier: ActivityWatch.ActivityWatch
           token: ${{ secrets.WINGET_TOKEN }}
+          fork-user: ActivityWatchBot

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@latest
         with:
           identifier: ActivityWatch.ActivityWatch
-          token: ${{ secrets.WINGET_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_WINGET_AUTOUPDATE }}
           fork-user: ActivityWatchBot

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest # action can only be run on windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: ActivityWatch.ActivityWatch
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Before merging this:
1. Please add a GitHub token with `public_repo` scope as a repository secret and rename the secret name in the workflow.
2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under @ActivityWatchBot.

> **Note** The Personal Access Token should come from the @ActivityWatchBot account.

* Resolves https://github.com/ActivityWatch/activitywatch/issues/752