### PR TITLE
ci(distribution): use versioned tag for winget-releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest # action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: ActivityWatch.ActivityWatch
           token: ${{ secrets.GH_TOKEN_WINGET_AUTOUPDATE }}


### PR DESCRIPTION
@ErikBjare please give token `workflow` permission also. You can re-run the job after that.

Reference: https://github.com/ActivityWatch/activitywatch/actions/runs/3130622310/jobs/5081066783