### PR TITLE
build(windows): during installation remove autostart entry before updating/reinstalling, to prevent duplicates

### DIFF
--- a/scripts/package/activitywatch-setup.iss
+++ b/scripts/package/activitywatch-setup.iss
@@ -61,3 +61,7 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 ; NOTE: Doesn't work? And also discouraged by the docs
 ;[InstallDelete]
 ;Type: filesandordirs; Name: "{app}\"
+
+; Removes the previously installed version before installing the new one
+[InstallDelete]
+Type: files; Name: "{userstartup}\{#MyAppName}"


### PR DESCRIPTION
No idea if this fixes it.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a00b53a83a615b83c684b66f422d4991605f236b  | 
|--------|

### Summary:
This PR updates the `activitywatch-setup.iss` script to remove existing autostart entries during installation, preventing duplicates.

**Key points**:
- Updated `activitywatch-setup.iss` to remove existing autostart entry during installation.
- Prevents duplicate autostart entries on reinstall/update.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
