### PR TITLE
build: add --add-version-header flag to build_changelog.py

### DIFF
--- a/scripts/build_changelog.py
+++ b/scripts/build_changelog.py
@@ -63,6 +63,11 @@ def main():
     parser.add_argument(
         "--output", default="changelog.md", help="Path to output changelog"
     )
+    parser.add_argument(
+        "--add-version-header",
+        action="store_true",
+        help="Add version header and adjust heading levels for docs",
+    )
 
     # parse args
     args = parser.parse_args()
@@ -88,6 +93,7 @@ def main():
         commit_range=(since, until),
         output_path=args.output,
         repo_order=repo_order,
+        add_version_header=args.add_version_header,
     )
 
 
@@ -352,6 +358,7 @@ def build(
     output_path: str,
     repo_order: List[str],
     filter_types: Optional[List[str]] = None,
+    add_version_header: bool = False,
 ):
     # provides a commit summary for the repo and subrepos, recursively looking up subrepos
     # NOTE: this must be done *before* `get_all_contributors` is called,
@@ -423,6 +430,12 @@ See the [getting started guide in the documentation](https://docs.activitywatch.
 
     if repo == "activitywatch":
         output = output.replace("# activitywatch", "# activitywatch (bundle repo)")
+
+    if add_version_header:
+        output = f"# {tag}\n\n" + output
+        output = output.replace("\n# Contributors\n", "\n## Contributors\n")
+        output = output.replace("\n# Changelog\n", "\n## Changelog\n")
+
     with open(output_path, "w") as f:
         f.write(output)
     print(f"Wrote {len(output.splitlines())} lines to {output_path}")


### PR DESCRIPTION
Add optional flag to prepend version header and adjust heading levels, useful for projects that want to include changelogs in their docs with proper heading hierarchy.

## Changes

When `--add-version-header` is enabled:
- Adds `# vX.Y.Z` header at the top
- Adjusts `# Contributors` to `## Contributors`
- Adjusts `# Changelog` to `## Changelog`

## Motivation

This keeps the default behavior unchanged while allowing docs-oriented projects (like [gptme](https://github.com/gptme/gptme)) to generate properly formatted release notes that integrate well with Sphinx/RST documentation.

The flag is opt-in and doesn't affect ActivityWatch's existing changelog generation workflow.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--add-version-header` flag to `build_changelog.py` to prepend version header and adjust heading levels for documentation integration.
> 
>   - **Behavior**:
>     - Adds `--add-version-header` flag to `build_changelog.py` to prepend `# vX.Y.Z` header and adjust heading levels.
>     - Changes `# Contributors` to `## Contributors` and `# Changelog` to `## Changelog` when flag is used.
>   - **Functions**:
>     - Updates `main()` to parse `--add-version-header` flag and pass it to `build()`.
>     - Modifies `build()` to apply header and heading adjustments based on `add_version_header` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Factivitywatch&utm_source=github&utm_medium=referral)<sup> for 04df7a1d05c2669d57485e25643f5c7c6a45d261. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->