### PR TITLE
`CONTRIBUTING.md` link to docs repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ There are many ways to contribute to ActivityWatch:
  - Implement new features.
    - Look among the [requested features][requested features] on the forum.
    - Talk to us in the issues or on [our Discord server][discord] to get help on how to proceed.
- - Write documentation.
+ - Write [documentation](https://github.com/ActivityWatch/docs).
  - Build the ecosystem.
    - Examples: New watchers, tools to analyze data, tools to import data from other sources, etc.
 


### PR DESCRIPTION
Make it a little easier to find docs repo from `CONTRIBUTING.md`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add direct link to documentation repository in `CONTRIBUTING.md`.
> 
>   - **Documentation**:
>     - Add direct link to the documentation repository in `CONTRIBUTING.md` under the "Write documentation" section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Factivitywatch&utm_source=github&utm_medium=referral)<sup> for 2987fa400b589a54559ba141595d77da0d3897b8. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->