### PR TITLE
fix(build): always sync canonical framework binary to avoid per-copy signature divergence

### DIFF
--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -183,10 +183,6 @@ if [ -n "$APPLE_PERSONALID" ]; then
                 if [ -z "$existing_id" ]; then
                     existing_id=$(basename "$canonical")
                 fi
-                # Snapshot the canonical checksum BEFORE signing — signing changes
-                # the binary bytes, so cmp -s after the fact always returns "differs"
-                # even when canonical and duplicates started as byte-identical copies.
-                canonical_presign=$(shasum "$canonical" | cut -d' ' -f1)
                 echo "    Signing canonical framework binary: $canonical (identifier: $existing_id)"
                 tmp_binary=$(mktemp)
                 cp -p "$canonical" "$tmp_binary"
@@ -197,34 +193,26 @@ if [ -n "$APPLE_PERSONALID" ]; then
                     "$tmp_binary" || { rm -f "$tmp_binary"; exit 1; }
                 cp "$tmp_binary" "$canonical" || { rm -f "$tmp_binary"; exit 1; }
                 rm -f "$tmp_binary"
-                # Copy the signed canonical to all duplicate paths so they share
-                # byte-identical signatures (Apple notarization checks all paths).
-                # Guard with PRE-SIGNING checksum so genuinely distinct binaries are
-                # signed separately rather than silently overwritten.
+                # Copy the signed canonical to ALL other paths unconditionally.
+                # PyInstaller signs each Python.framework copy independently during the
+                # watcher build (aw.spec codesign_identity), giving each a different
+                # embedded signature (different timestamp nonce). After cp -r into the
+                # .app, all three paths (Python, Versions/Current/Python, Versions/3.9/Python)
+                # carry pre-existing but DIFFERENT signatures, so a pre-sign SHA comparison
+                # never detects them as duplicates — all three end up signed separately,
+                # producing three divergent signatures that Apple rejects as "invalid".
+                #
+                # The correct fix: always sync the signed canonical to every other path,
+                # making all copies byte-identical including the embedded signature.
+                # These paths are always the same Python binary; independently signing
+                # them is the root of every Apple rejection in this fallback block.
                 synced_count=0
-                separately_count=0
                 for fw_bin in "${fw_bins[@]:1}"; do
-                    if [ "$(shasum "$fw_bin" | cut -d' ' -f1)" = "$canonical_presign" ]; then
-                        echo "    Syncing signed binary to duplicate path: $fw_bin"
-                        cp "$canonical" "$fw_bin" || exit 1
-                        ((synced_count++))
-                    else
-                        echo "    WARNING: $fw_bin differs from canonical; signing separately" >&2
-                        tmp2=$(mktemp)
-                        fw_id=$(codesign -d "$fw_bin" 2>&1 | sed -n 's/^Identifier=//p' || true)
-                        [ -z "$fw_id" ] && fw_id=$(basename "$fw_bin")
-                        cp -p "$fw_bin" "$tmp2"
-                        codesign --force --options runtime --timestamp \
-                            --entitlements "$ENTITLEMENTS" \
-                            --identifier "$fw_id" \
-                            --sign "$APPLE_PERSONALID" \
-                            "$tmp2" || { rm -f "$tmp2"; exit 1; }
-                        cp "$tmp2" "$fw_bin" || { rm -f "$tmp2"; exit 1; }
-                        rm -f "$tmp2"
-                        ((separately_count++))
-                    fi
+                    echo "    Syncing signed binary to path: $fw_bin"
+                    cp "$canonical" "$fw_bin" || exit 1
+                    ((synced_count++))
                 done
-                echo "  Signed $((1 + separately_count)) + synced ${synced_count} duplicate(s) inside $fw"
+                echo "  Signed 1 + synced ${synced_count} path(s) inside $fw"
             else
                 echo "ERROR: Failed to sign $fw: $sign_output" >&2
                 exit 1

--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -210,7 +210,7 @@ if [ -n "$APPLE_PERSONALID" ]; then
                 for fw_bin in "${fw_bins[@]:1}"; do
                     echo "    Syncing signed binary to path: $fw_bin"
                     cp "$canonical" "$fw_bin" || exit 1
-                    ((synced_count++))
+                    synced_count=$((synced_count + 1))
                 done
                 echo "  Signed 1 + synced ${synced_count} path(s) inside $fw"
             else


### PR DESCRIPTION
## Root cause

PR #1257 added a pre-signing SHA guard to detect whether `Python.framework/Python`, `Versions/Current/Python`, and `Versions/3.9/Python` are duplicates before syncing from canonical. The guard fails because **PyInstaller already signed each copy independently** (via `codesign_identity` in `aw.spec`) during the watcher build, giving each path a different embedded signature (different timestamp nonce).

After `cp -r` into the reassembled `.app`, all three paths carry pre-existing but **different** signatures. The SHA comparison never matches, all three fall through to the "sign separately" path, and Apple rejects all three as `"The signature of the binary is invalid"`.

Evidence from post-#1257 master Build Tauri run [24217849800](https://github.com/ActivityWatch/activitywatch/actions/runs/24217849800) — all 9 paths still rejected (3 watchers × 3 Python.framework paths), confirming the dedup never fired.

## Fix

Remove the SHA guard and always sync the signed canonical to all other paths in the `Python.framework` fallback. These paths are always the same Python binary; independently signing them is what causes the Apple rejection.

This reduces the fallback block from ~30 lines to ~10 lines.

## Why this is safe

- We're only in this fallback when `codesign` reports "bundle format is ambiguous" — specifically for non-standard PyInstaller-embedded `Python.framework` bundles
- `Python`, `Versions/Current/Python`, `Versions/3.9/Python` are always the same binary (different alias paths for the same Python interpreter)
- Apple requires byte-identical signatures across all three — unconditional sync is the only approach that achieves this