### PR TITLE
fix(build): preserve identifiers in strip-and-sync framework fallback

### DIFF
--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -153,66 +153,64 @@ if [ -n "$APPLE_PERSONALID" ]; then
             --sign "$APPLE_PERSONALID" \
             "$fw" 2>&1) && echo "  Signed bundle: $fw" || {
             if echo "$sign_output" | grep -q "bundle format is ambiguous"; then
-                echo "  Note: $fw lacks standard bundle structure; signing canonical Mach-O binary and syncing to duplicates"
+                echo "  Note: $fw lacks standard bundle structure; strip-signing and syncing duplicates by content hash"
                 # PyInstaller copies Python.framework contents as separate files rather
                 # than symlinks — Python, Versions/Current/Python, and Versions/3.9/Python
-                # are distinct inodes with identical content.
+                # are distinct inodes with identical code but different embedded signatures
+                # (different timestamp nonces in __LINKEDIT from PyInstaller's own
+                # codesign_identity). After cp -r into the .app, all three paths carry
+                # pre-existing but DIFFERENT signatures. A pre-sign SHA comparison
+                # never detects them as duplicates, so all three end up signed separately,
+                # producing three divergent signatures that Apple rejects as "invalid".
                 #
-                # Signing each independently produces three different signatures (different
-                # timestamps, different random nonces in the signature block). Apple's
-                # notarization service detects these as inconsistently signed and reports
-                # "The signature of the binary is invalid" for all three paths.
-                #
-                # Fix: sign only the FIRST (canonical) binary via temp copy, then copy
-                # the signed result to all duplicate paths. All three end up with byte-
-                # identical content including the embedded signature, so Apple's hash
-                # check passes for every path.
-                fw_bins=()
+                # Fix: strip all existing signatures first (making copies truly identical
+                # at the byte level), then group by content hash, sign one canonical per
+                # group via temp copy, and sync the signed result to all group members.
+                # This is correct even if the framework contains genuinely different
+                # binaries — only true duplicates share a signed payload.
+                tmp_group_dir=$(mktemp -d)
+                found_macho=false
                 while IFS= read -r fw_bin; do
-                    fw_bins+=("$fw_bin")
+                    found_macho=true
+                    existing_id=$(codesign -d "$fw_bin" 2>&1 \
+                        | sed -n 's/^Identifier=//p' || true)
+                    if [ -z "$existing_id" ]; then
+                        existing_id="$(basename "$fw_bin")"
+                    fi
+
+                    # Strip any existing signature (from PyInstaller or prior attempts)
+                    # so content hashing identifies true duplicates rather than
+                    # nonce-only signature differences from previous signing steps.
+                    codesign --remove-signature "$fw_bin" 2>/dev/null || true
+                    content_hash=$(shasum -a 256 "$fw_bin" | awk '{print $1}')
+                    canonical_path_file="$tmp_group_dir/$content_hash.path"
+
+                    if [ -f "$canonical_path_file" ]; then
+                        # Same binary content — sync signed payload from canonical.
+                        canonical="$canonical_path_file"
+                        echo "    Syncing signed binary to duplicate: $fw_bin"
+                        cp "$canonical" "$fw_bin"
+                    else
+                        # First occurrence of this content — sign it as canonical.
+                        echo "    Signing canonical binary: $fw_bin (identifier: $existing_id, hash: ${content_hash:0:12})"
+                        tmp_binary=$(mktemp)
+                        cp -p "$fw_bin" "$tmp_binary"
+                        codesign --force --options runtime --timestamp \
+                            --entitlements "$ENTITLEMENTS" \
+                            --identifier "$existing_id" \
+                            --sign "$APPLE_PERSONALID" \
+                            "$tmp_binary" || { rm -f "$tmp_binary"; rm -rf "$tmp_group_dir"; exit 1; }
+                        cp "$tmp_binary" "$fw_bin"
+                        # Save signed canonical as the source for duplicates.
+                        cp "$tmp_binary" "$canonical_path_file"
+                        rm -f "$tmp_binary"
+                    fi
                 done < <(find "$fw" -type f | xargs file | grep "Mach-O" | cut -d: -f1 | sort)
-                if [ "${#fw_bins[@]}" -eq 0 ]; then
+                rm -rf "$tmp_group_dir"
+                if ! $found_macho; then
                     echo "ERROR: No Mach-O binaries found inside $fw" >&2
                     exit 1
                 fi
-                # Sign the canonical (first) binary via temp copy to avoid the
-                # in-place "bundle format is ambiguous" error from codesign.
-                canonical="${fw_bins[0]}"
-                existing_id=$(codesign -d "$canonical" 2>&1 \
-                    | sed -n 's/^Identifier=//p' || true)
-                if [ -z "$existing_id" ]; then
-                    existing_id=$(basename "$canonical")
-                fi
-                echo "    Signing canonical framework binary: $canonical (identifier: $existing_id)"
-                tmp_binary=$(mktemp)
-                cp -p "$canonical" "$tmp_binary"
-                codesign --force --options runtime --timestamp \
-                    --entitlements "$ENTITLEMENTS" \
-                    --identifier "$existing_id" \
-                    --sign "$APPLE_PERSONALID" \
-                    "$tmp_binary" || { rm -f "$tmp_binary"; exit 1; }
-                cp "$tmp_binary" "$canonical" || { rm -f "$tmp_binary"; exit 1; }
-                rm -f "$tmp_binary"
-                # Copy the signed canonical to ALL other paths unconditionally.
-                # PyInstaller signs each Python.framework copy independently during the
-                # watcher build (aw.spec codesign_identity), giving each a different
-                # embedded signature (different timestamp nonce). After cp -r into the
-                # .app, all three paths (Python, Versions/Current/Python, Versions/3.9/Python)
-                # carry pre-existing but DIFFERENT signatures, so a pre-sign SHA comparison
-                # never detects them as duplicates — all three end up signed separately,
-                # producing three divergent signatures that Apple rejects as "invalid".
-                #
-                # The correct fix: always sync the signed canonical to every other path,
-                # making all copies byte-identical including the embedded signature.
-                # These paths are always the same Python binary; independently signing
-                # them is the root of every Apple rejection in this fallback block.
-                synced_count=0
-                for fw_bin in "${fw_bins[@]:1}"; do
-                    echo "    Syncing signed binary to path: $fw_bin"
-                    cp "$canonical" "$fw_bin" || exit 1
-                    synced_count=$((synced_count + 1))
-                done
-                echo "  Signed 1 + synced ${synced_count} path(s) inside $fw"
             else
                 echo "ERROR: Failed to sign $fw: $sign_output" >&2
                 exit 1


### PR DESCRIPTION
## Summary
- preserve the original codesign identifier before stripping signatures in the non-standard framework fallback
- sign the canonical binary with that identifier, then sync the signed copy to duplicate framework paths
- keep the existing strip-and-sync approach, but avoid falling back to path-derived identifiers like `Python`

## Why
`Build Tauri` on `master` is still failing on macOS in run 24240587094 after #1258. The notarization rejection log shows all embedded `Python.framework` copies are still rejected as `The signature of the binary is invalid`.

The current strip-and-sync fallback fixed divergent signatures, but it re-signs the canonical binary without preserving the original identifier. For these embedded Python binaries, that means codesign uses the path/basename-derived identifier (`Python`) instead of the original binary identifier, which is exactly the regression fixed earlier in ActivityWatch/activitywatch#1255.

This patch reapplies that lesson to the strip-and-sync fallback: capture the original identifier before removing the signature, then pass it explicitly during re-signing.

## Verification
- `bash -n scripts/package/build_app_tauri.sh`
- inspected notarization rejection log from run 24240587094 / job 70773894191
