### PR TITLE
fix(build): restore Python.framework symlinks before signing

### DIFF
--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -57,7 +57,14 @@ echo "Fixing Python.framework symlink structure..."
 while IFS= read -r fw; do
     echo "  Fixing: $fw"
     # Find the actual version directory (e.g., "3.9"), skipping "Current"
-    version_dir=$(ls "$fw/Versions/" 2>/dev/null | grep -v Current | head -1)
+    version_dir=""
+    for d in "$fw/Versions"/*/; do
+        bname="$(basename "$d")"
+        if [ "$bname" != "Current" ] && [ -d "$d" ]; then
+            version_dir="$bname"
+            break
+        fi
+    done
     if [ -z "$version_dir" ]; then
         echo "  Warning: No version directory found in $fw/Versions/, skipping"
         continue
@@ -76,8 +83,7 @@ while IFS= read -r fw; do
             ln -s "Versions/Current/$item" "$fw/$item"
         fi
     done
-done < <(find "dist/${APP_NAME}.app" -type d -name "*.framework" \
-    | grep -i python)
+done < <(find "dist/${APP_NAME}.app" -type d -iname "Python.framework")
 
 echo "Setting executable permissions..."
 find "dist/${APP_NAME}.app/Contents/Resources" -type f -name "aw-*" -exec chmod +x {} \;

--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -45,6 +45,40 @@ for component in dist/activitywatch/*/; do
     fi
 done
 
+echo "Fixing Python.framework symlink structure..."
+# PyInstaller copies Python.framework using regular files/directories instead of
+# preserving the standard macOS symlink layout. Without symlinks, codesign rejects
+# the framework with "bundle format is ambiguous (could be app or framework)".
+# Restore the canonical layout so codesign can sign it as a proper framework bundle:
+#   Versions/Current -> <version>  (symlink)
+#   Python -> Versions/Current/Python  (symlink)
+#   Resources -> Versions/Current/Resources  (symlink)
+#   Headers -> Versions/Current/Headers  (symlink, if present)
+while IFS= read -r fw; do
+    echo "  Fixing: $fw"
+    # Find the actual version directory (e.g., "3.9"), skipping "Current"
+    version_dir=$(ls "$fw/Versions/" 2>/dev/null | grep -v Current | head -1)
+    if [ -z "$version_dir" ]; then
+        echo "  Warning: No version directory found in $fw/Versions/, skipping"
+        continue
+    fi
+
+    # Replace Versions/Current directory with a symlink to the version dir
+    if [ -d "$fw/Versions/Current" ] && [ ! -L "$fw/Versions/Current" ]; then
+        rm -rf "$fw/Versions/Current"
+        ln -s "$version_dir" "$fw/Versions/Current"
+    fi
+
+    # Replace root-level copies with symlinks into Versions/Current/
+    for item in Python Resources Headers; do
+        if [ -e "$fw/$item" ] && [ ! -L "$fw/$item" ]; then
+            rm -rf "$fw/$item"
+            ln -s "Versions/Current/$item" "$fw/$item"
+        fi
+    done
+done < <(find "dist/${APP_NAME}.app" -type d -name "*.framework" \
+    | grep -i python)
+
 echo "Setting executable permissions..."
 find "dist/${APP_NAME}.app/Contents/Resources" -type f -name "aw-*" -exec chmod +x {} \;
 


### PR DESCRIPTION
## Summary

- Restores standard macOS framework symlink structure in Python.framework before code signing
- Root cause of all recent notarization failures (#1255, #1258, #1259): PyInstaller copies Python.framework using regular files/directories instead of symlinks, causing `codesign` to reject it with "bundle format is ambiguous" and triggering a fallback path that never produces valid *framework bundle* signatures
- Apple's notarization rejects because the individual-binary signing approach doesn't create the `_CodeSignature/CodeResources` seal that Apple expects for `.framework` bundles

Verified locally that restoring symlinks fixes the signing:
- **Without symlinks**: `codesign` → "bundle format is ambiguous" (current CI behavior)
- **With symlinks**: `codesign` → signs and verifies successfully

## What changed

After `cp -r` copies watcher components into the `.app`, a new step finds all `Python.framework` directories and restores the canonical layout:

```
Python.framework/
  Python -> Versions/Current/Python          (was a copy)
  Resources -> Versions/Current/Resources    (was a copy)
  Versions/
    Current -> 3.9                           (was a directory)
    3.9/
      Python      (the actual binary - unchanged)
      Resources/  (unchanged)
```

The existing fallback code (strip-sign-sync) is left in place as a safety net but should no longer trigger for Python.framework.

## Test plan

- [ ] CI Build Tauri macOS jobs should pass (both `macos-14` and `macos-latest`)
- [ ] Notarization should succeed (no more "The signature of the binary is invalid" rejections)
- [ ] After merge, `Create dev release` workflow should produce `v0.13.3b1`

Fixes ActivityWatch/activitywatch#1216
Related: ErikBjare/bob#546