### PR TITLE
ci: drop redundant macos-14 from CI matrix

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -31,7 +31,6 @@ jobs:
             ubuntu-24.04,
             ubuntu-24.04-arm,
             windows-latest,
-            macos-14,
             macos-latest,
           ]
         python_version: [3.9]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-latest, macos-14, macos-latest]
+        os: [ubuntu-24.04, windows-latest, macos-latest]
         python_version: [3.9]
         node_version: [22]
         skip_rust: [false]


### PR DESCRIPTION
## Summary

- Remove `macos-14` from both `build.yml` and `build-tauri.yml` CI matrices
- `macos-latest` now resolves to `macos-15-arm64`, same architecture as `macos-14` — running both is redundant
- `macos-14` is [being deprecated by GitHub Actions in July 2026](https://github.com/actions/runner-images/issues/13518)