### PR TITLE
ci: add -tauri suffix to Tauri build release assets

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -164,7 +164,7 @@ jobs:
 
             make dist/notarize
           fi
-          mv dist/ActivityWatch.dmg dist/activitywatch-${VERSION_TAG:-$(scripts/package/getversion.sh)}-macos-x86_64.dmg
+          mv dist/ActivityWatch.dmg dist/activitywatch-tauri-${VERSION_TAG:-$(scripts/package/getversion.sh)}-macos-x86_64.dmg
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -164,7 +164,7 @@ jobs:
 
             make dist/notarize
           fi
-          mv dist/ActivityWatch.dmg dist/activitywatch-tauri-${VERSION_TAG:-$(scripts/package/getversion.sh)}-macos-x86_64.dmg
+          mv dist/ActivityWatch.dmg dist/activitywatch-tauri-${VERSION_TAG:-$(scripts/package/getversion.sh)}-macos-$(uname -m).dmg
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
           # Notarize
           make dist/notarize
         fi
-        mv dist/ActivityWatch.dmg dist/activitywatch-${VERSION_TAG:-$(scripts/package/getversion.sh)}-macos-x86_64.dmg
+        mv dist/ActivityWatch.dmg dist/activitywatch-${VERSION_TAG:-$(scripts/package/getversion.sh)}-macos-$(uname -m).dmg
       env:
         APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}

--- a/scripts/package/package-all.sh
+++ b/scripts/package/package-all.sh
@@ -41,7 +41,12 @@ function get_arch() {
 platform=$(get_platform)
 version=$(get_version)
 arch=$(get_arch)
-echo "Platform: $platform, arch: $arch, version: $version"
+# Suffix to distinguish Tauri builds from aw-qt builds in release assets
+build_suffix=""
+if [[ $TAURI_BUILD == "true" ]]; then
+    build_suffix="-tauri"
+fi
+echo "Platform: $platform, arch: $arch, version: $version, tauri: ${TAURI_BUILD:-false}"
 
 # For Tauri Linux builds, include helper scripts and README
 if [[ $platform == "linux" && $TAURI_BUILD == "true" ]]; then
@@ -51,7 +56,7 @@ fi
 function build_zip() {
     echo "Zipping executables..."
     pushd dist;
-    filename="activitywatch-${version}-${platform}-${arch}.zip"
+    filename="activitywatch${build_suffix}-${version}-${platform}-${arch}.zip"
     echo "Name of package will be: $filename"
 
     if [[ $platform == "windows"* ]]; then
@@ -64,7 +69,7 @@ function build_zip() {
 }
 
 function build_setup() {
-    filename="activitywatch-${version}-${platform}-${arch}-setup.exe"
+    filename="activitywatch${build_suffix}-${version}-${platform}-${arch}-setup.exe"
     echo "Name of package will be: $filename"
 
     innosetupdir="/c/Program Files (x86)/Inno Setup 6"


### PR DESCRIPTION
## Summary

- Both `build.yml` and `build-tauri.yml` upload to the same GitHub release with identical filenames, causing silent overwrites
- Adds `-tauri` suffix to Tauri build filenames so both aw-qt and Tauri assets coexist

Before: `activitywatch-v0.14.0b1-linux-x86_64.zip` (ambiguous)
After: `activitywatch-tauri-v0.14.0b1-linux-x86_64.zip` (Tauri) vs `activitywatch-v0.14.0b1-linux-x86_64.zip` (aw-qt)

Affects zip, dmg, and Windows setup.exe. AppImage and deb are aw-qt only, unchanged.