### PR TITLE
.2059806565729300:ea2bd6200ad210607021cd167237f62b_69e3499ab13256d09ece8088.69e3996bb13256d09ece81a4.69e3996a7afba9383018b935:Trae CN.T(2026/4/18 22:47:07)

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -55,6 +55,21 @@ jobs:
         run: |
           echo "VERSION_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
+      - name: Determine and output version
+        run: |
+          VERSION_WITH_V=$(bash scripts/package/getversion.sh)
+          VERSION_NO_V=$(bash scripts/package/getversion.sh --strip-v)
+          echo "VERSION_WITH_V=${VERSION_WITH_V}" >> $GITHUB_ENV
+          echo "VERSION_NO_V=${VERSION_NO_V}" >> $GITHUB_ENV
+          echo "========================================"
+          echo "Build Version Information (Tauri)"
+          echo "========================================"
+          echo "GitHub ref: ${{ github.ref }}"
+          echo "GitHub ref_name: ${{ github.ref_name }}"
+          echo "Version (with v):  ${VERSION_WITH_V}"
+          echo "Version (no v):     ${VERSION_NO_V}"
+          echo "========================================"
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,21 @@ jobs:
       run: |
         echo "VERSION_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
+    - name: Determine and output version
+      run: |
+        VERSION_WITH_V=$(bash scripts/package/getversion.sh)
+        VERSION_NO_V=$(bash scripts/package/getversion.sh --strip-v)
+        echo "VERSION_WITH_V=${VERSION_WITH_V}" >> $GITHUB_ENV
+        echo "VERSION_NO_V=${VERSION_NO_V}" >> $GITHUB_ENV
+        echo "========================================"
+        echo "Build Version Information"
+        echo "========================================"
+        echo "GitHub ref: ${{ github.ref }}"
+        echo "GitHub ref_name: ${{ github.ref_name }}"
+        echo "Version (with v):  ${VERSION_WITH_V}"
+        echo "Version (no v):     ${VERSION_NO_V}"
+        echo "========================================"
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -6,7 +6,8 @@ set -e
 
 APP_NAME="ActivityWatch"
 BUNDLE_ID="net.activitywatch.ActivityWatch"
-VERSION="0.1.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="$("$SCRIPT_DIR/getversion.sh" --strip-v)"
 ICON_PATH="aw-tauri/src-tauri/icons/icon.icns"
 
 if [[ "$(uname)" != "Darwin" ]]; then

--- a/scripts/package/getversion.sh
+++ b/scripts/package/getversion.sh
@@ -1,19 +1,89 @@
 #!/bin/bash
+set -e
 
-# TODO: Merge with scripts/package/getversion.sh
-# set -e
+SCRIPT_NAME="$(basename "$0")"
+STRIP_V=false
 
-if [[ $TRAVIS_TAG ]]; then
-    _version=$TRAVIS_TAG;
-elif [[ $APPVEYOR_REPO_TAG_NAME ]]; then
-    _version=$APPVEYOR_REPO_TAG_NAME;
-else
-    # Exact
-    _version=$(git describe --tags --abbrev=0 --exact-match 2>/dev/null)
-    if [[ -z $_version ]]; then
-        # Latest tag + commit ID
-        _version="$(git describe --tags --abbrev=0).dev-$(git rev-parse --short HEAD)"
+show_usage() {
+    cat << EOF
+Usage: $SCRIPT_NAME [OPTIONS]
+
+Get the version of ActivityWatch from git tags or CI environment variables.
+
+Options:
+    --strip-v, --no-v    Remove the 'v' prefix from the version (if present)
+    --help, -h           Show this help message
+
+Environment Variables (used in CI, checked in priority order):
+    GITHUB_REF_NAME      GitHub Actions tag/ref (e.g., "v0.14.0")
+    TRAVIS_TAG           Travis CI tag
+    APPVEYOR_REPO_TAG_NAME AppVeyor CI tag
+
+Version Format:
+    - Release tag: v0.14.0
+    - Dev version: v0.14.0.dev-abc1234
+    - Beta/RC: v0.14.0b1, v0.14.0rc1
+
+Examples:
+    $SCRIPT_NAME                    # v0.14.0 or v0.14.0.dev-abc1234
+    $SCRIPT_NAME --strip-v          # 0.14.0 or 0.14.0.dev-abc1234
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --strip-v|--no-v)
+                STRIP_V=true
+                shift
+                ;;
+            --help|-h)
+                show_usage
+                exit 0
+                ;;
+            *)
+                echo "ERROR: Unknown argument: $1" >&2
+                show_usage >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
+get_version_internal() {
+    local _version=""
+    
+    if [[ -n "$GITHUB_REF_NAME" && "$GITHUB_REF_NAME" == v* ]]; then
+        _version="$GITHUB_REF_NAME"
+    elif [[ -n "$TRAVIS_TAG" ]]; then
+        _version="$TRAVIS_TAG"
+    elif [[ -n "$APPVEYOR_REPO_TAG_NAME" ]]; then
+        _version="$APPVEYOR_REPO_TAG_NAME"
+    else
+        _version="$(git describe --tags --abbrev=0 --exact-match 2>/dev/null || true)"
+        if [[ -z "$_version" ]]; then
+            local _latest_tag
+            _latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")"
+            local _commit_hash
+            _commit_hash="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+            _version="${_latest_tag}.dev-${_commit_hash}"
+        fi
     fi
-fi
+    
+    echo "$_version"
+}
 
-echo $_version;
+main() {
+    parse_args "$@"
+    
+    local version
+    version="$(get_version_internal)"
+    
+    if $STRIP_V; then
+        version="$(echo "$version" | sed -e 's/^v//')"
+    fi
+    
+    echo "$version"
+}
+
+main "$@"

--- a/scripts/package/package-all.sh
+++ b/scripts/package/package-all.sh
@@ -29,8 +29,14 @@ function get_platform() {
     echo $_platform;
 }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 function get_version() {
-    $(dirname "$0")/getversion.sh;
+    "$SCRIPT_DIR/getversion.sh";
+}
+
+function get_version_no_prefix() {
+    "$SCRIPT_DIR/getversion.sh" --strip-v;
 }
 
 function get_arch() {
@@ -40,13 +46,23 @@ function get_arch() {
 
 platform=$(get_platform)
 version=$(get_version)
+version_no_prefix=$(get_version_no_prefix)
 arch=$(get_arch)
-# Suffix to distinguish Tauri builds from aw-qt builds in release assets
 build_suffix=""
 if [[ $TAURI_BUILD == "true" ]]; then
     build_suffix="-tauri"
 fi
-echo "Platform: $platform, arch: $arch, version: $version, tauri: ${TAURI_BUILD:-false}"
+
+echo "========================================"
+echo "Build Version Information"
+echo "========================================"
+echo "Platform:       $platform"
+echo "Arch:           $arch"
+echo "Version (with v):  $version"
+echo "Version (no v):     $version_no_prefix"
+echo "Tauri build:    ${TAURI_BUILD:-false}"
+echo "========================================"
+echo
 
 # For Tauri Linux builds, include helper scripts and README
 if [[ $platform == "linux" && $TAURI_BUILD == "true" ]]; then
@@ -78,8 +94,6 @@ function build_setup() {
         exit 1
     fi
 
-    # Windows installer version should not include 'v' prefix, see: https://github.com/microsoft/winget-pkgs/pull/17564
-    version_no_prefix="$(echo $version | sed -e 's/^v//')"
     if [[ $TAURI_BUILD == "true" ]]; then
         env AW_VERSION=$version_no_prefix "$innosetupdir/iscc.exe" scripts/package/aw-tauri.iss
     else

--- a/scripts/package/package-deb.sh
+++ b/scripts/package/package-deb.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/bash
-# Setting the shell is required, as `sh` doesn't support slicing.
 
 # Fail fast
 set -e
 # Verbose commands for CI verification
 set -x
 
-VERSION=$(scripts/package/getversion.sh)
-# Slice off the "v" from the tag, which is probably guaranteed
-VERSION_NUM=${VERSION:1}
-echo $VERSION_NUM
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="$("$SCRIPT_DIR/getversion.sh")"
+VERSION_NUM="$("$SCRIPT_DIR/getversion.sh" --strip-v)"
+echo "Version (with v): $VERSION"
+echo "Version (without v): $VERSION_NUM"
 PKGDIR="activitywatch_$VERSION_NUM"
 
 # Package tools


### PR DESCRIPTION
重构版本号获取脚本，统一处理不同CI环境和本地环境的版本号获取
添加版本信息输出功能，便于调试和验证构建版本
修改相关脚本以使用新的版本号获取方式