### PR TITLE
docs: update donation badge to reflect April 2026 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
   <br>
 
   <a href="https://activitywatch.net/donate/">
-    <img title="Donated" src="https://img.shields.io/badge/budget-%24201%2Fmo%20from%2040%20supporters-orange.svg" />
+    <img title="Donated" src="https://img.shields.io/badge/budget-~%24275%2Fmo%20from%2044%20supporters-orange.svg" />
   </a>
   <a href="https://doi.org/10.5281/zenodo.4957165">
     <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4957165.svg" />


### PR DESCRIPTION
Updates the shields.io badge from $201/mo (40 supporters) to ~$275/mo (44 supporters), based on current Open Collective data.

**Baseline (Open Collective, 30 days ending 2026-04-30):**
- 4 contributions, $274.67 total
- 44 lifetime contributors, $8,465 all-time received

Ref: ErikBjare/bob#336