### PR TITLE
ci(build-tauri): expose Linux AppImage and deb as standalone release artifacts

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -187,6 +187,24 @@ jobs:
           CERTIFICATE_MACOS_P12_BASE64: ${{ secrets.CERTIFICATE_MACOS_P12_BASE64 }}
           CERTIFICATE_MACOS_P12_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_P12_PASSWORD }}
 
+      - name: Package AppImage and deb (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # aw-tauri's package target produces AppImage/deb alongside the zip;
+          # copy them to dist/ so the Upload step picks them up as standalone artifacts.
+          APPIMAGE=$(find dist/activitywatch/aw-tauri -name "*.AppImage" 2>/dev/null | head -1)
+          if [ -n "$APPIMAGE" ]; then
+            cp "$APPIMAGE" "dist/activitywatch-tauri-${VERSION_WITH_V}-linux-$(uname -m).AppImage"
+            echo "Packaged AppImage: dist/activitywatch-tauri-${VERSION_WITH_V}-linux-$(uname -m).AppImage"
+          else
+            echo "Warning: no AppImage found in dist/activitywatch/aw-tauri/"
+          fi
+          DEB=$(find dist/activitywatch/aw-tauri -name "*.deb" 2>/dev/null | head -1)
+          if [ -n "$DEB" ]; then
+            cp "$DEB" "dist/activitywatch-tauri-${VERSION_WITH_V}-linux-$(uname -m).deb"
+            echo "Packaged deb: dist/activitywatch-tauri-${VERSION_WITH_V}-linux-$(uname -m).deb"
+          fi
+
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Fixes #1300.

## Problem

After `make package`, aw-tauri already builds an `.AppImage` and `.deb` — these land inside `dist/activitywatch/aw-tauri/` (and end up zipped inside the `.zip` release). But the Upload step only picks up files matching `dist/activitywatch-*.*`, so the AppImage and deb were never exposed as standalone downloadable artifacts in CI or releases.

The macOS workflow already has a dedicated "Package dmg" step that moves the `.dmg` to `dist/` with the right name. Linux had no equivalent.

## Fix

Add a Linux-specific step (mirroring "Package dmg") that copies the AppImage and deb out to `dist/` using the standard naming convention:

```
dist/activitywatch-tauri-<version>-linux-<arch>.AppImage
dist/activitywatch-tauri-<version>-linux-<arch>.deb
```

These then get picked up by the existing `Upload packages` step and included in releases.

## Test plan

- [ ] CI on this PR shows both `activitywatch-tauri-*-linux-x86_64.AppImage` and `.deb` in the uploaded artifacts for the ubuntu runners
- [ ] ARM build similarly produces `aarch64` variants