### PR TITLE
ci(build-tauri): expose Linux AppImage/deb/rpm bundles as artifacts

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -159,6 +159,22 @@ jobs:
           poetry install
           make package SKIP_SERVER_RUST=${{ matrix.skip_rust }}
 
+      - name: Package Linux (Tauri bundles)
+        if: runner.os == 'Linux'
+        run: |
+          # aw-tauri's bundler produces .AppImage/.deb/.rpm under
+          # dist/activitywatch/aw-tauri/ via `make package`. Copy them out with
+          # versioned, arch-suffixed filenames so they match the
+          # `dist/activitywatch-*.*` upload pattern below.
+          ARCH=$(uname -m)
+          shopt -s nullglob
+          for src in dist/activitywatch/aw-tauri/*.AppImage \
+                     dist/activitywatch/aw-tauri/*.deb \
+                     dist/activitywatch/aw-tauri/*.rpm; do
+            ext="${src##*.}"
+            cp -v "$src" "dist/activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}.${ext}"
+          done
+
       - name: Package dmg
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -168,11 +168,13 @@ jobs:
           # `dist/activitywatch-*.*` upload pattern below.
           ARCH=$(uname -m)
           shopt -s nullglob
-          for src in dist/activitywatch/aw-tauri/*.AppImage \
-                     dist/activitywatch/aw-tauri/*.deb \
-                     dist/activitywatch/aw-tauri/*.rpm; do
-            ext="${src##*.}"
-            cp -v "$src" "dist/activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}.${ext}"
+          for ext in AppImage deb rpm; do
+            files=( dist/activitywatch/aw-tauri/*.${ext} )
+            case ${#files[@]} in
+              0) continue ;;
+              1) cp -v "${files[0]}" "dist/activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}.${ext}" ;;
+              *) echo "ERROR: expected at most 1 .${ext} bundle, found ${#files[@]}" >&2; exit 1 ;;
+            esac
           done
 
       - name: Package dmg


### PR DESCRIPTION
## Problem

`aw-tauri`'s Tauri bundler already produces `.AppImage`, `.deb`, and `.rpm` files under `dist/activitywatch/aw-tauri/` on Linux runs, but the `upload-artifact` step in `.github/workflows/build-tauri.yml` only globs `dist/activitywatch-*.*`. As a result the Linux Tauri bundles were silently dropped from build artifacts (and from drafted releases), even though Linux ZIPs do get uploaded.

This is what @ErikBjare flagged in #1300:

> @TimeToBuildBob that PR is to the aw-tauri repo, not this bundle repo. PR needed to this repo too.

## Change

Add a Linux-only `Package Linux (Tauri bundles)` step that copies the bundler outputs out with versioned, arch-suffixed filenames so they match the existing upload glob:

- `activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}.AppImage`
- `activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}.deb`
- `activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}.rpm`

`shopt -s nullglob` keeps the step a no-op if any extension is missing (e.g. if rpm packaging is disabled in `tauri.conf.json` for some build), instead of failing on a literal `*.rpm` glob.

## Out of scope

- No changes to Windows or macOS jobs
- No changes to `build.yml` (non-Tauri build, already has its own AppImage/deb steps)
- aw-tauri's own arm64 ARCH detection is broken (`uname -m` returns `aarch64` on Linux arm64 but the Makefile checks for `arm64`); that's an aw-tauri Makefile bug, not part of this PR

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-tauri.yml'))"`)
- Workflow lint will run on the PR
- Final verification will be the next master push, where the Tauri Linux runs should produce `activitywatch-tauri-*-linux-x86_64.{AppImage,deb,rpm}` artifacts visible in the workflow run

Closes the bundle-repo half of #1300.