### PR TITLE
fix(ci): follow higher prerelease line when one already exists

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -85,6 +85,22 @@ jobs:
           fi
 
           next_base=$(bump_version "${latest_stable#v}" "$RELEASE_LINE")
+
+          # If a prerelease for a version ahead of next_base already exists, continue
+          # that release line instead of starting a new one from the stable bump.
+          # e.g. latest_stable=v0.13.2 + patch → v0.13.3, but if v0.14.0b1 already
+          # exists we should produce v0.14.0b2, not v0.13.3b1.
+          highest_prerelease=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+b[0-9]+$' | head -1 || true)
+          if [ -n "$highest_prerelease" ]; then
+            hp_base="${highest_prerelease%%b*}"
+            hp_base="${hp_base#v}"
+            if [ "$(printf '%s\n%s\n' "$hp_base" "$next_base" | sort -V | tail -1)" = "$hp_base" ] && \
+               [ "$hp_base" != "$next_base" ]; then
+              echo "Existing prerelease $highest_prerelease is ahead of computed v${next_base}; continuing that release line."
+              next_base="$hp_base"
+            fi
+          fi
+
           prerelease_pattern="^v${next_base//./\\.}b[0-9]+$"
           last_prerelease=$(git tag --sort=-version:refname | grep -E "$prerelease_pattern" | head -1 || true)
 


### PR DESCRIPTION
## Problem

The `dev-release` workflow computes `next_base` by bumping `latest_stable` by the configured `RELEASE_LINE` (defaulting to `patch`). It then looks for existing prereleases matching that specific version. But it never checks whether a prerelease for a *newer* version already exists.

Concretely: `latest_stable = v0.13.2`, `RELEASE_LINE = patch` → `next_base = 0.13.3`. The workflow only looks for `v0.13.3bN` tags, ignoring that `v0.14.0b1` already existed. This caused the scheduled run to draft `v0.13.3b1` and `v0.13.3b2` — stale patch prereleases behind the already-in-flight minor release line.

Fixes #1307.

## Fix

After computing `next_base`, find the highest existing prerelease tag across all versions. If it's for a version newer than `next_base`, use that version's base instead — continuing the in-flight release line rather than starting a stale one.

```
latest_stable=v0.13.2, next_base=0.13.3, highest_prerelease=v0.14.0b1
→ hp_base=0.14.0 > 0.13.3 → next_base overridden to 0.14.0
→ next_tag=v0.14.0b2 ✓
```

## Test plan

- [ ] Verify the preflight script logic manually: tag a repo with `v0.13.2` + `v0.14.0b1`, run the script with `RELEASE_LINE=patch` — `next_tag` should be `v0.14.0b2`
- [ ] Trigger the workflow via `workflow_dispatch` to confirm it produces `v0.14.0b2` next
- [ ] Delete the stale `v0.13.3b1` / `v0.13.3b2` draft releases that were incorrectly created