### PR TITLE
fix(ci): pin WebKit to 2.44.0-2 to fix blank-webview regression in Linux builds

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -116,12 +116,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libgtk-3-dev \
-            libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
-            libjavascriptcoregtk-4.1-dev \
             libsoup-3.0-dev \
             xdg-utils
+          # Pin WebKit to avoid blank-webview regression on newer ubuntu-24.04 packages
+          # See: ActivityWatch/aw-tauri#99
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-0=2.44.0-2 \
+            libwebkit2gtk-4.1-dev=2.44.0-2 \
+            libjavascriptcoregtk-4.1-0=2.44.0-2 \
+            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+            gir1.2-webkit2-4.1=2.44.0-2
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Pins the webkit2gtk and javascriptcoregtk packages to version `2.44.0-2` in the `build-tauri.yml` Linux APT dependency installation step.

The ubuntu-24.04 runners can resolve newer webkit2gtk versions that cause blank webviews in the resulting AppImage builds. This is the same fix already applied in ActivityWatch/aw-tauri#99 for the standalone aw-tauri release workflow; this PR brings the parent repo's build-tauri.yml in sync.

**Before:** unpinned `libwebkit2gtk-4.1-dev` and `libjavascriptcoregtk-4.1-dev` — vulnerable to whatever the latest ubuntu-24.04 packages resolve to.

**After:** pinned `=2.44.0-2` for all webkit/javascriptcoregtk packages, plus adds the runtime libs (`libwebkit2gtk-4.1-0`, `libjavascriptcoregtk-4.1-0`) and GIR packages that aw-tauri#99 identified as needed.

## Related

- ActivityWatch/aw-tauri#97 — blank webview regression report
- ActivityWatch/aw-tauri#99 — same fix in the standalone aw-tauri workflow
- Raised in v0.14.0b1 release discussion by @0xbrayo