### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs (supply chain hardening)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,6 +22,6 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' && github.actor == 'dependabot[bot]'
 
     steps:
-      - uses: ridedott/merge-me-action@v2
+      - uses: ridedott/merge-me-action@e45e8ab1dd3d3dc1d27b8c0a3f465e40e8c9fb8e # v2
         with:
           GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}

--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -20,7 +20,7 @@ jobs:
           git clone https://github.com/ActivityWatch/docs
           git clone https://github.com/ActivityWatch/activitywatch.github.io
       - name: Update diagram
-        uses: githubocto/repo-visualizer@main
+        uses: githubocto/repo-visualizer@a999615bdab757559bf94bda1fe6eef232765f85 # main
         with:
           commit_message: 'chore: update diagram [skip ci]'
           file_colors: '{"rs": "#b7410e", "py": "#229922", "rst": "pink", "txt": "pink", "md": "pink", "css": "purple", "scss": "purple"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,7 @@ jobs:
 
       - name: Set up Rust
         if: ${{ !matrix.skip_rust }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         id: toolchain
         with:
           toolchain: stable
@@ -479,7 +479,7 @@ jobs:
 
       - name: Set up Rust
         if: ${{ !matrix.skip_rust }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         id: toolchain
         with:
           toolchain: stable
@@ -535,7 +535,7 @@ jobs:
           pip3 install poetry==1.4.2
 
       - name: Build
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           timeout_minutes: 60
           max_attempts: 3
@@ -548,7 +548,7 @@ jobs:
             pip freeze
 
       - name: Run tests
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           timeout_minutes: 60
           max_attempts: 3
@@ -625,7 +625,7 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0
 
-      - uses: ActivityWatch/check-version-format-action@v2
+      - uses: ActivityWatch/check-version-format-action@5b223bd718c4c00466359532cf944474f069625a # v2.0.1
         id: version
         with:
           prefix: 'v'
@@ -673,13 +673,13 @@ jobs:
         run: ls -R
         working-directory: dist
 
-      - uses: ActivityWatch/check-version-format-action@v2
+      - uses: ActivityWatch/check-version-format-action@5b223bd718c4c00466359532cf944474f069625a # v2.0.1
         id: version
         with:
           prefix: 'v'
 
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: true
           files: dist/*/activitywatch-*.*

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest # action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: ActivityWatch.ActivityWatch
           token: ${{ secrets.GH_TOKEN_WINGET_AUTOUPDATE }}


### PR DESCRIPTION
## Summary

All 10 external action references in the CI workflows were using mutable tags or branch names. A tag or branch is a movable pointer — whoever controls the upstream action repository (or anyone who compromises it) can re-point it, and the next workflow run executes the new code with the job's token and any available secrets.

This was flagged by Thibaud Van Den Berghe (thibaud@getplumber.io), who identified the pattern by running the [Plumber CLI](https://github.com/getplumber/plumber) against the repo. The same attack vector was exploited in **CVE-2025-30066** (tj-actions/changed-files), where a moved tag caused CI secrets to be dumped in every consuming repository on the next run.

## Changes

Each third-party action is now pinned to its current commit SHA with the human-readable version in a comment:

| File | Action | Was | Now |
|---|---|---|---|
| `release.yml` (×2) | `dtolnay/rust-toolchain` | `@master` | `@3c5f7ea` |
| `release.yml` (×2) | `nick-fields/retry` | `@v4` | `@ad984534` |
| `release.yml` | `softprops/action-gh-release` | `@v3` | `@b4309332` |
| `release.yml` (×2) | `ActivityWatch/check-version-format-action` | `@v2` | `@5b223bd` (v2.0.1) |
| `diagram.yml` | `githubocto/repo-visualizer` | `@main` | `@a999615` |
| `dependabot-automerge.yml` | `ridedott/merge-me-action` | `@v2` | `@e45e8ab` |
| `winget.yml` | `vedantmgoyal2009/winget-releaser` | `@v2` | `@4ffc7888` |

The priority targets (`dtolnay/rust-toolchain@master` and `softprops/action-gh-release@v3`) were in the release pipeline and had access to publishing credentials. `githubocto/repo-visualizer@main` had `contents: write` on a moving branch.

`github/codeql-action` (GitHub-maintained) is left for a separate pass — it's lower risk than third-party actions.

## Keeping SHAs current

To avoid SHA rot, consider adding [Renovate](https://docs.renovatebot.com/modules/manager/github-actions/) or [pinact](https://github.com/suzuki-shunsuke/pinact) to keep these pinned references updated automatically when upstream releases new versions.