### PR TITLE
fix(ci): bump MACOSX_DEPLOYMENT_TARGET 10.9 -> 10.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       AW_EXTRAS: true
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: 10.12
     defaults:
       run:
         shell: bash
@@ -415,7 +415,7 @@ jobs:
     env:
       AW_EXTRAS: true
       TAURI_BUILD: true
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: 10.12
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
`rustc` no longer supports a macOS deployment target below 10.12. Every Rust compile in the macOS Qt and Tauri jobs currently emits:

```
warning: deployment target in MACOSX_DEPLOYMENT_TARGET was set to 10.9, but the minimum supported by `rustc` is 10.12
```

~36 occurrences per release run. macOS 10.9–10.11 are long past Apple's support window (10.12 Sierra is from 2016), so raise the floor to 10.12 to silence the warnings. No functional change to supported targets in practice.