### PR TITLE
fix(ci): upgrade poetry 1.4.2 -> 2.3.2 and relock aw-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install innosetup
           fi
-          pip3 install poetry==2.3.2
+          pip3 install poetry==2.2.1
 
       - name: Build
         run: |
@@ -532,7 +532,7 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install innosetup
           fi
-          pip3 install poetry==2.3.2
+          pip3 install poetry==2.2.1
 
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,7 +336,7 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install innosetup
           fi
-          pip3 install poetry==1.4.2
+          pip3 install poetry==2.3.2
 
       - name: Build
         run: |
@@ -532,7 +532,7 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install innosetup
           fi
-          pip3 install poetry==1.4.2
+          pip3 install poetry==2.3.2
 
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ version = "0.14.0"
 description = "The free and open-source automated time tracker. Cross-platform, extensible, privacy-focused."
 authors = ["Erik Bjäreholt <erik@bjareho.lt>", "Johan Bjäreholt <johan@bjareho.lt>"]
 license = "MPL-2.0"
+# This is an aggregator project (deps only, no `activitywatch` package to build).
+# Poetry 2.x defaults to package-mode and would fail with "No file/folder found
+# for package activitywatch"; disable it so `poetry install` only manages deps.
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
## Problem

All the committed `poetry.lock` files are already in **Poetry 2.x format** (lock-version 2.0/2.1, generated by Poetry 2.0–2.3), but CI installs `poetry==1.4.2`, which can't read them. Every job logs, repeatedly:

```
The lock file might not be compatible with the current version of Poetry.
Upgrade Poetry to ensure the lock file is read properly or, alternatively,
regenerate the lock file with the `poetry lock` command.
```

A separate, real warning appeared only for **aw-core**:

```
Warning: poetry.lock is not consistent with pyproject.toml.
You may be getting improper dependencies.
```

I checked every submodule lock with Poetry 2.3.2 (`poetry check --lock`) — aw-core was the **only** one genuinely inconsistent; the rest were just being misread by the ancient CI poetry.

## Fix

1. Pin `poetry==2.3.2` (lines 339 & 535) — the toolchain the locks were generated with — so they're read correctly. The locks being newer than CI's poetry means 2.x is the *correct* tool here, not a risky upgrade.
2. Bump the **aw-core** submodule to pull in its relock (ActivityWatch/aw-core#140). That diff is only the content-hash + generator version + one normalized constraint — no dependency versions change.

## Validation

This triggers the full build matrix (Qt + Tauri × macOS/Linux/Windows). Watching it to confirm `poetry install`/`make build` behave under poetry 2.x before merge.

Part of the CI-reliability cleanup alongside #1326 (aw-watcher-window flake) and #1327 (MACOSX_DEPLOYMENT_TARGET).