### PR TITLE
[codex] fix(ci): resolve macOS codesign identity from imported cert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,6 +368,12 @@ jobs:
         run: |
           if [ -n "$APPLE_EMAIL" ]; then
             ./scripts/ci/import-macos-p12.sh
+            APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\\(.*\\)"/\\1/p' | head -1)
+            if [ -z "$APPLE_PERSONALID" ]; then
+              echo "ERROR: no codesigning identity found after importing the macOS certificate" >&2
+              exit 1
+            fi
+            export APPLE_PERSONALID
           fi
 
           source venv/bin/activate
@@ -386,7 +392,7 @@ jobs:
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_PERSONALID: ${{ secrets.APPLE_TEAMID }}
+          APPLE_PERSONALID: ""
           APPLE_TEAMID: ${{ secrets.APPLE_TEAMID }}
           CERTIFICATE_MACOS_P12_BASE64: ${{ secrets.CERTIFICATE_MACOS_P12_BASE64 }}
           CERTIFICATE_MACOS_P12_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_P12_PASSWORD }}
@@ -586,6 +592,12 @@ jobs:
         run: |
           if [ -n "$APPLE_EMAIL" ]; then
             ./scripts/ci/import-macos-p12.sh
+            APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\\(.*\\)"/\\1/p' | head -1)
+            if [ -z "$APPLE_PERSONALID" ]; then
+              echo "ERROR: no codesigning identity found after importing the macOS certificate" >&2
+              exit 1
+            fi
+            export APPLE_PERSONALID
           fi
 
           source venv/bin/activate
@@ -604,7 +616,7 @@ jobs:
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_PERSONALID: ${{ secrets.APPLE_TEAMID }}
+          APPLE_PERSONALID: ""
           APPLE_TEAMID: ${{ secrets.APPLE_TEAMID }}
           CERTIFICATE_MACOS_P12_BASE64: ${{ secrets.CERTIFICATE_MACOS_P12_BASE64 }}
           CERTIFICATE_MACOS_P12_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_P12_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,7 @@ jobs:
         run: |
           if [ -n "$APPLE_EMAIL" ]; then
             ./scripts/ci/import-macos-p12.sh
-            APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\\(.*\\)"/\\1/p' | head -1)
+            APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\(.*\)"/\1/p' | head -1)
             if [ -z "$APPLE_PERSONALID" ]; then
               echo "ERROR: no codesigning identity found after importing the macOS certificate" >&2
               exit 1
@@ -380,7 +380,7 @@ jobs:
           make dist/ActivityWatch.dmg
 
           if [ -n "$APPLE_EMAIL" ]; then
-            codesign --force --verbose --timestamp -s ${APPLE_PERSONALID} dist/ActivityWatch.dmg
+            codesign --force --verbose --timestamp -s "${APPLE_PERSONALID}" dist/ActivityWatch.dmg
 
             brew install akeru-inc/tap/xcnotary
             xcnotary precheck dist/ActivityWatch.app
@@ -592,7 +592,7 @@ jobs:
         run: |
           if [ -n "$APPLE_EMAIL" ]; then
             ./scripts/ci/import-macos-p12.sh
-            APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\\(.*\\)"/\\1/p' | head -1)
+            APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\(.*\)"/\1/p' | head -1)
             if [ -z "$APPLE_PERSONALID" ]; then
               echo "ERROR: no codesigning identity found after importing the macOS certificate" >&2
               exit 1
@@ -604,7 +604,7 @@ jobs:
           make dist/ActivityWatch.dmg
 
           if [ -n "$APPLE_EMAIL" ]; then
-            codesign --force --verbose --timestamp -s ${APPLE_PERSONALID} dist/ActivityWatch.dmg
+            codesign --force --verbose --timestamp -s "${APPLE_PERSONALID}" dist/ActivityWatch.dmg
 
             brew install akeru-inc/tap/xcnotary
             xcnotary precheck dist/ActivityWatch.app

--- a/scripts/ci/import-macos-p12.sh
+++ b/scripts/ci/import-macos-p12.sh
@@ -1,23 +1,23 @@
 #!/bin/sh
 
-set -e
+set -eu
 
-# Source: https://www.update.rocks/blog/osx-signing-with-travis/
-export KEY_CHAIN=build.keychain
-export CERTIFICATE_P12=aw_certificate.p12
+export KEY_CHAIN="${KEY_CHAIN:-build.keychain-db}"
+export CERTIFICATE_P12="${CERTIFICATE_P12:-aw_certificate.p12}"
 
-# Recreate the certificate from the secure environment variable
-echo $CERTIFICATE_MACOS_P12_BASE64 | base64 --decode > $CERTIFICATE_P12
+# Recreate the certificate from the secure environment variable.
+printf '%s' "$CERTIFICATE_MACOS_P12_BASE64" | base64 --decode > "$CERTIFICATE_P12"
 
-#create a keychain
-security -v create-keychain -p travis $KEY_CHAIN
-# Make the keychain the default so identities are found
-security -v default-keychain -s $KEY_CHAIN
-# Unlock the keychain
-security -v unlock-keychain -p travis $KEY_CHAIN
+# Recreate the temporary keychain on every run so stale state cannot leak between jobs.
+security -v delete-keychain "$KEY_CHAIN" >/dev/null 2>&1 || true
+security -v create-keychain -p travis "$KEY_CHAIN"
+security -v default-keychain -s "$KEY_CHAIN"
+security -v unlock-keychain -p travis "$KEY_CHAIN"
+security -v set-keychain-settings -lut 21600 "$KEY_CHAIN"
+security -v list-keychains -d user -s "$KEY_CHAIN" login.keychain-db login.keychain
 
-security -v import $CERTIFICATE_P12 -k $KEY_CHAIN -P $CERTIFICATE_MACOS_P12_PASSWORD -A
-security -v set-key-partition-list -S apple-tool:,apple: -s -k travis $KEY_CHAIN
+security -v import "$CERTIFICATE_P12" -k "$KEY_CHAIN" -P "$CERTIFICATE_MACOS_P12_PASSWORD" -A
+security -v set-key-partition-list -S apple-tool:,apple: -s -k travis "$KEY_CHAIN"
+security -v find-identity -v -p codesigning "$KEY_CHAIN"
 
-# remove certs
-rm -rf *.p12
+rm -f "$CERTIFICATE_P12"


### PR DESCRIPTION
## What changed
- resolve the macOS codesigning identity from the certificate that was actually imported into the temporary keychain
- harden `scripts/ci/import-macos-p12.sh` for current `macos-latest` runners by recreating the keychain, setting the search list, and printing discovered codesigning identities for debugging
- stop pre-populating `APPLE_PERSONALID` from `APPLE_TEAMID`, since the packaging step now derives the real signing identity after import

## Why
`master` release CI started failing on July 1, 2026 in both macOS release jobs. The failing step was `codesign` during `Package dmg`, with errors like `no identity found` and `The specified item could not be found in the keychain`.

The existing workflow depended on a brittle `APPLE_PERSONALID` value and an old keychain import flow. This patch makes the workflow use the identity that macOS actually exposes after import, which is what `codesign` needs.

## Impact
This should unblock the `Release` workflow on `master` for both Qt and Tauri macOS builds without changing Linux or Windows packaging.

## Validation
- `git diff --check`
- `bash -n scripts/ci/import-macos-p12.sh`
- inspected failing runs `28523138998` and `28523116461`

Local end-to-end signing was not possible here because the Apple certificate secrets and a macOS runner are only available in GitHub Actions.
