### PR TITLE
fix(scripts): replace deprecated pip --format=legacy in uninstall.sh

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-modules=$(pip3 list --format=legacy | grep 'aw-' | grep -o '^aw-[^ ]*')
+modules=$(pip3 list --format=freeze | grep '^aw-' | cut -d'=' -f1)
 
 for module in $modules; do
     pip3 uninstall -y $module


### PR DESCRIPTION
## Problem

`scripts/uninstall.sh` uses `pip3 list --format=legacy`, but the `legacy` format was removed in pip 23.0 (released 2023-01-30). Running the script errors out with:

```
option --format: invalid choice: 'legacy' (choose from 'columns', 'freeze', 'json')
```

As a result, `$modules` is always empty and nothing gets uninstalled.

Fixes #1343.

## Fix

Switch to `--format=freeze` (outputs `package==version` per line, available since pip's earliest versions) and use `cut -d'=' -f1` to extract just the package name.

**Before:**
```bash
modules=$(pip3 list --format=legacy | grep 'aw-' | grep -o '^aw-[^ ]*')
```

**After:**
```bash
modules=$(pip3 list --format=freeze | grep '^aw-' | cut -d'=' -f1)
```

## Testing

Verified locally with pip 23.x — `pip3 list --format=freeze | grep '^aw-' | cut -d'=' -f1` produces correct package names without version suffixes.