### PR TITLE
fix(ci): build Qt AppImage on Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-latest, macos-latest]
+        # Build Linux Qt/AppImage artifacts on the oldest supported runner to
+        # keep the bundled glibc baseline compatible with older distributions.
+        os: [ubuntu-22.04, windows-latest, macos-latest]
         python_version: [3.9]
         node_version: [22]
         skip_rust: [false]


### PR DESCRIPTION
## What

- Builds the Linux Qt artifact matrix on `ubuntu-22.04` instead of `ubuntu-24.04`.
- Leaves the Tauri Linux matrix on `ubuntu-24.04`/`ubuntu-24.04-arm` because it currently depends on the WebKitGTK 4.1 package pin from ActivityWatch/aw-tauri#99.

## Why

The standalone Qt AppImage is the release asset users hit first for older Linux distributions. Building it on Ubuntu 22.04 lowers the glibc baseline compared with Noble-built artifacts, which should make it more compatible across older distros.

This follows up the older-distro AppImage discussion in https://github.com/orgs/ActivityWatch/discussions/1297#discussioncomment-17462292.

## Verification

- Parsed `.github/workflows/release.yml` with PyYAML.
