### PR TITLE
fix(ci): ignore pytest 9 until Python 3.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,13 @@ updates:
 
   # Maintain dependencies for pip/poetry
   # NOTE: too noisy, easier to update by hand
-  #- package-ecosystem: "pip"
-  #  directory: "/"
-  #  schedule:
-  #    interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      # pytest 9.0.3 is the first non-vulnerable release, but it requires
+      # Python >=3.10 while ActivityWatch still builds/releases on Python 3.9.
+      - dependency-name: "pytest"
+        versions: [">=9"]


### PR DESCRIPTION
## Root cause

Dependabot's security update job for root `pytest` is failing on `master` because the alert wants `pytest >=9.0.3`, but `pytest 9.0.3` requires Python `>=3.10`. The root Poetry project still declares Python `^3.9`, and release CI still builds Python 3.9 artifacts, so Dependabot can only resolve up to `pytest 8.4.2`.

Failed run: https://github.com/ActivityWatch/activitywatch/actions/runs/28720321500

## Fix

Adds an active root `pip` Dependabot entry with `open-pull-requests-limit: 0`, preserving the existing "pip updates are too noisy" policy, and ignores `pytest >=9` until ActivityWatch intentionally drops Python 3.9.

## Verification

- Parsed `.github/dependabot.yml` with PyYAML.
- Asserted the root pip entry has `open-pull-requests-limit: 0` and the `pytest >=9` ignore rule.
- Verified from PyPI metadata: `pytest 8.4.2` supports `>=3.9`; `pytest 9.0.3` requires `>=3.10`.
