### PR TITLE
fix(ci): sign macOS artifacts only on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,18 @@ jobs:
       - name: Package dmg
         if: runner.os == 'macOS'
         run: |
-          if [ -n "$APPLE_EMAIL" ]; then
+          SIGN_MACOS=false
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            SIGN_MACOS=true
+          fi
+
+          if [ "$SIGN_MACOS" = true ]; then
+            for var in APPLE_EMAIL APPLE_PASSWORD APPLE_TEAMID CERTIFICATE_MACOS_P12_BASE64 CERTIFICATE_MACOS_P12_PASSWORD; do
+              if [ -z "${!var:-}" ]; then
+                echo "ERROR: $var is required to sign macOS release artifacts" >&2
+                exit 1
+              fi
+            done
             ./scripts/ci/import-macos-p12.sh
             APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\(.*\)"/\1/p' | head -1)
             if [ -z "$APPLE_PERSONALID" ]; then
@@ -381,7 +392,7 @@ jobs:
           source venv/bin/activate
           make dist/ActivityWatch.dmg
 
-          if [ -n "$APPLE_EMAIL" ]; then
+          if [ "$SIGN_MACOS" = true ]; then
             codesign --force --verbose --timestamp -s "${APPLE_PERSONALID}" dist/ActivityWatch.dmg
 
             brew install akeru-inc/tap/xcnotary
@@ -592,7 +603,18 @@ jobs:
       - name: Package dmg
         if: runner.os == 'macOS'
         run: |
-          if [ -n "$APPLE_EMAIL" ]; then
+          SIGN_MACOS=false
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            SIGN_MACOS=true
+          fi
+
+          if [ "$SIGN_MACOS" = true ]; then
+            for var in APPLE_EMAIL APPLE_PASSWORD APPLE_TEAMID CERTIFICATE_MACOS_P12_BASE64 CERTIFICATE_MACOS_P12_PASSWORD; do
+              if [ -z "${!var:-}" ]; then
+                echo "ERROR: $var is required to sign macOS release artifacts" >&2
+                exit 1
+              fi
+            done
             ./scripts/ci/import-macos-p12.sh
             APPLE_PERSONALID=$(security find-identity -v -p codesigning "${KEY_CHAIN:-build.keychain-db}" | sed -n 's/.*"\(.*\)"/\1/p' | head -1)
             if [ -z "$APPLE_PERSONALID" ]; then
@@ -605,7 +627,7 @@ jobs:
           source venv/bin/activate
           make dist/ActivityWatch.dmg
 
-          if [ -n "$APPLE_EMAIL" ]; then
+          if [ "$SIGN_MACOS" = true ]; then
             codesign --force --verbose --timestamp -s "${APPLE_PERSONALID}" dist/ActivityWatch.dmg
 
             brew install akeru-inc/tap/xcnotary


### PR DESCRIPTION
## Root cause

Master push run https://github.com/ActivityWatch/activitywatch/actions/runs/28720318129 fails only in the macOS `Package dmg` steps. The P12 imports, but `security find-identity -v -p codesigning` reports `0 valid identities found`, so the repository signing certificate/chain is currently not usable on the runner.

Branch pushes are CI signals, not release publications. They should still build DMGs, but stale signing secrets should not make every master push red. Tagged `v*` releases are the place where signing/notarization must remain mandatory.

## Change

- Gate macOS signing/notarization on `GITHUB_REF == refs/tags/v*` in both Qt and Tauri DMG packaging steps.
- Keep unsigned DMG creation for branch/PR builds.
- On release tags, fail fast if signing credentials are missing or if the imported certificate does not produce a valid codesigning identity.

## Verification

- `bash -n` on the changed DMG packaging shell block.
- Parsed `.github/workflows/release.yml` with PyYAML.

This should clear master CI for ordinary pushes while still surfacing the real signing-secret problem before publishing a tagged release.
