### PR TITLE
fix(uninstall): use --format=freeze (pip 23.0 removed --format=legacy)

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-modules=$(pip3 list --format=legacy | grep 'aw-' | grep -o '^aw-[^ ]*')
+# pip removed --format=legacy in 23.0 (2023-01-30); use --format=freeze which
+# outputs `aw-core==0.5.x` and is stable across pip versions.
+modules=$(pip3 list --format=freeze | grep '^aw-' | grep -o '^aw-[^=]*')
 
 for module in $modules; do
     pip3 uninstall -y $module
 done
-


### PR DESCRIPTION
Fixes #1343.

pip 23.0 (2023-01-30) removed the deprecated `--format=legacy`, so on any modern pip `scripts/uninstall.sh` bails out with:

```
option --format: invalid choice: 'legacy' (choose from 'columns', 'freeze', 'json')
```

The outer `grep 'aw-'` then reads empty stdin, `$modules` is empty, the loop is a no-op — and the user thinks uninstall worked.

Switched to `--format=freeze` (output shape `aw-core==0.5.x`), which is stable across all supported pip versions. Also tweaked the second `grep -o` to strip on `=` instead of space so it still picks up just the package name.

Quick check:

```console
$ echo -e 'aw-core==0.5.16\naw-client==0.5.13\nfoo==1.0' | grep '^aw-' | grep -o '^aw-[^=]*'
aw-core
aw-client
```

`bash -n scripts/uninstall.sh` passes.
