### PR TITLE
fix(ci): use team ID for notarytool keychain profile name

### DIFF
--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -3,7 +3,10 @@
 applemail=$APPLE_EMAIL # Email address used for Apple ID
 password=$APPLE_PASSWORD # See apps-specific password https://support.apple.com/en-us/HT204397
 teamid=$APPLE_TEAMID # Team idenitifer (if single developer, then set to developer identifier)
-keychain_profile="activitywatch-$APPLE_PERSONALID"  # name of the keychain profile to use
+# Name of the keychain profile to use. Must not contain spaces: APPLE_PERSONALID
+# holds the full codesign identity ("Developer ID Application: ..."), so use the
+# team ID instead.
+keychain_profile="activitywatch-$APPLE_TEAMID"
 bundleid=net.activitywatch.ActivityWatch # Match aw.spec
 app=dist/ActivityWatch.app
 dmg=dist/ActivityWatch.dmg
@@ -12,13 +15,13 @@ dmg=dist/ActivityWatch.dmg
 run_notarytool() {
     dist=$1
     # Setup the credentials for notarization
-    xcrun notarytool store-credentials $keychain_profile --apple-id $applemail --team-id $teamid --password $password
+    xcrun notarytool store-credentials "$keychain_profile" --apple-id "$applemail" --team-id "$teamid" --password "$password"
     # Notarize and wait; tee to a temp file so output streams in real-time
     # while we can still inspect it afterward for failure details.
     echo "Notarization: starting for $dist"
     echo "Notarization: in progress for $dist"
     tmpfile=$(mktemp)
-    xcrun notarytool submit $dist --keychain-profile $keychain_profile --wait 2>&1 | tee "$tmpfile"
+    xcrun notarytool submit "$dist" --keychain-profile "$keychain_profile" --wait 2>&1 | tee "$tmpfile"
     submission_exit=${PIPESTATUS[0]}
     submission_output=$(cat "$tmpfile")
     rm -f "$tmpfile"
@@ -29,7 +32,7 @@ run_notarytool() {
         if [ -n "$uuid" ]; then
             echo ""
             echo "=== Notarization rejected (status: Invalid) — fetching rejection log for $uuid ==="
-            xcrun notarytool log "$uuid" --keychain-profile $keychain_profile 2>&1 || true
+            xcrun notarytool log "$uuid" --keychain-profile "$keychain_profile" 2>&1 || true
             echo "=== End of rejection log ==="
         fi
         return 1


### PR DESCRIPTION
## Problem

The `v0.14.0b2` re-run ([29498340371](https://github.com/ActivityWatch/activitywatch/actions/runs/29498340371)) got past signing after the `CERTIFICATE_MACOS_P12_BASE64` secret was rotated to the new 2025 Developer ID cert, but then failed in notarization:

```
Error: 5 unexpected arguments: 'ID', 'Application:', 'Erik', 'Bjareholt', '(***)'
```

Since #1337, `APPLE_PERSONALID` is derived from `security find-identity` and holds the **full identity string** (`Developer ID Application: Erik Bjareholt (TEAMID)`) instead of the short repo secret it used to be. `notarize.sh` used it unquoted as part of the notarytool keychain profile name, so the spaces word-split into stray arguments and every `store-credentials`/`submit` call failed. This was masked until now because the expired cert made the job fail before reaching notarization.

## Fix

- Base the keychain profile name on `APPLE_TEAMID` (no spaces, stable) instead of `APPLE_PERSONALID`.
- Quote the `notarytool` arguments in `run_notarytool`.

## Context

Part of unblocking the v0.14.0b3 beta (see ActivityWatch/activitywatch#1339 and the beta blocker tracker). The notarization path itself only runs on `v*` tags, so CI here can't exercise it; verified the word-splitting logic locally.