### PR TITLE
fix(ci): bump MACOSX_DEPLOYMENT_TARGET from 10.9 to 12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     env:
       AW_EXTRAS: true
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     defaults:
       run:
         shell: bash
@@ -434,7 +434,7 @@ jobs:
     env:
       AW_EXTRAS: true
       TAURI_BUILD: true
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     defaults:
       run:
         shell: bash

--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -127,7 +127,7 @@ cat > "dist/${APP_NAME}.app/Contents/Info.plist" << EOF
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.14</string>
+    <string>${MACOSX_DEPLOYMENT_TARGET:-12.0}</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
## Problem

The submodule bump (372fd95) pulled in ActivityWatch/aw-watcher-window#126, which compiles the Swift helper with `-target $(arch)-apple-macosx$(MACOSX_DEPLOYMENT_TARGET)`, defaulting to 14.0 but overridable via env (`?=`). This workflow still exported `MACOSX_DEPLOYMENT_TARGET: 10.9` — below rustc's 10.12 floor (#1327) and Swift Foundation's 10.10 minimum — so both macOS jobs on master ([run 29907762087](https://github.com/ActivityWatch/activitywatch/actions/runs/29907762087)) failed compiling `macos.swift`:

```
error: 'URL' is only available in macOS 10.10 or newer
```

## Fix

Set `MACOSX_DEPLOYMENT_TARGET: "12.0"` in both macOS build jobs.

**Why 12.0 and not upstream's 14.0:** 14.0 in aw-watcher-window#126 was chosen to stop the runner-default (macOS 15) target from leaking in — not because the code needs macOS 14 APIs. Compiling `macos.swift` at various targets (both arches) shows the true floor is 12.0: Swift concurrency (`Task`) needs 10.15, `Date.now` needs 12. Targeting 12.0:

- still fixes the Swift build (verified: compiles OK at 12.0 for x86_64 and arm64; fails at 10.15 and below)
- still avoids the aw-watcher-window#125-class Sonoma dyld crash (any explicit target ≤ user's OS does)
- satisfies rustc's 10.12 minimum, subsuming #1327
- keeps a future x86_64/universal build (#1263) usable on Intel Macs back to ~2014–15 (Monterey) instead of 2018+ (Sonoma)

Current builds are arm64-only, so today this only affects arm64 (floor 11.0 anyway); the Intel-relevant part matters when #1263 restores x86_64 artifacts.

Follow-up worth doing upstream: lower aw-watcher-window's Makefile default (and its minos CI check) from 14.0 to 12.0 to match.

## Context

Last blocker for re-cutting the v0.14.0b2 release (signing + notarization fixed in #1362 and via secret rotation; see ActivityWatch/activitywatch#1339).