### PR TITLE
feat(ci): restore x86_64 macOS builds via macos-15-intel runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
       matrix:
         # Build Linux Qt/AppImage artifacts on the oldest supported runner to
         # keep the bundled glibc baseline compatible with older distributions.
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-latest, macos-latest, macos-15-intel]
         python_version: [3.9]
         node_version: [22]
         skip_rust: [false]
@@ -448,6 +448,7 @@ jobs:
             ubuntu-24.04-arm,
             windows-latest,
             macos-latest,
+            macos-15-intel,
           ]
         python_version: [3.9]
         node_version: [22]


### PR DESCRIPTION
## What

Adds `macos-15-intel` to both the Qt and Tauri build matrices, restoring Intel macOS artifacts dropped when the matrix moved to `macos-latest` (arm64). Closes #1263 (option 2).

## Why this is viable again

GitHub retired the free `macos-13` x86_64 image, but introduced **`macos-15-intel`** as its designated standard-image successor specifically due to OSS demand — see [actions/runner-images#13045](https://github.com/actions/runner-images/issues/13045). It is available until **August 2027**, and is the **last** x86_64 image GitHub Actions will ever offer; after that the options are universal binaries built on arm64 or dropping Intel for good. Since arm64 binaries do **not** run on Intel via Rosetta (translation is x86_64→arm64 only), this runner is currently the only practical way to ship Intel-capable artifacts.

## Why it should just work

- With `MACOSX_DEPLOYMENT_TARGET=12.0` (#1363), x86_64 artifacts support Intel Macs back to ~2014–15 (Monterey); the Swift helper verifiably compiles for `x86_64-apple-macosx12.0`
- Artifact names already use `uname -m` (#1262) → `...-macos-x86_64.dmg`
- All macOS steps key off `runner.os == 'macOS'`, none off `macos-latest`
- Signing/notarization run per-matrix-job on separate runners; the Developer ID cert is arch-independent

## Sequencing

Suggest merging **after** the v0.14.0b2 re-release is cut, so the beta isn't blocked if the Intel job surfaces surprises. This PR's own CI exercises the full x86_64 build path (unsigned).