### PR TITLE
fix(ci): upgrade poetry 1.4.2 -> 2.2.1 and add package-mode = false

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,7 +338,7 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install innosetup
           fi
-          pip3 install poetry==1.4.2
+          pip3 install poetry==2.2.1
 
       - name: Build
         run: |
@@ -551,7 +551,7 @@ jobs:
           if [ "$RUNNER_OS" == "Windows" ]; then
             choco install innosetup
           fi
-          pip3 install poetry==1.4.2
+          pip3 install poetry==2.2.1
 
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.14.0"
 description = "The free and open-source automated time tracker. Cross-platform, extensible, privacy-focused."
 authors = ["Erik Bjäreholt <erik@bjareho.lt>", "Johan Bjäreholt <johan@bjareho.lt>"]
 license = "MPL-2.0"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
## Problem

All submodule `poetry.lock` files are already in Poetry 2.x format (lock-version 2.0/2.1), but CI installs `poetry==1.4.2`, which can't read them. Every job logs the compatibility warning repeatedly. This fix was originally PR #1328, but that branch had accumulated a month of drift and stale submodule/workflow history that made it non-trivial to rebase — so this is a fresh PR with only the two-file change that matters.

## Fix

1. Pin `poetry==2.2.1` in both Qt and Tauri build steps in `release.yml`
   - 2.2.1 is the latest Poetry 2.x release that supports Python ≥ 3.9; 2.3.x requires ≥ 3.10, which conflicts with the matrix's `python-version: 3.9`
2. Add `package-mode = false` to the root `pyproject.toml`
   - Required for Poetry 2.x: the root aggregator has no installable packages, so Poetry 2 raises an error without this flag

## What's NOT changed (vs #1328)

- The `aw-core` submodule is left at `c4d31b8` (current master pointer) — the relock from aw-core#140 is already an ancestor, so that change is already included
- No other workflow changes

## Validation

Triggers the full build matrix. The previous run on current master (run [29907291656](https://github.com/ActivityWatch/activitywatch/actions/runs/29907291656)) showed all jobs passing but with repeated Poetry lock-format warnings — this PR removes those warnings.

Closes #1328