### PR TITLE
feat(changelog): link previous release in 'Changes since' header

### DIFF
--- a/scripts/build_changelog.py
+++ b/scripts/build_changelog.py
@@ -380,7 +380,7 @@ def build(
     output_changelog = f"""
 # Changelog
 
-Changes since {since}:
+Changes since [{since}](https://github.com/{org}/{repo}/releases/tag/{since}):
 
 {output_changelog}
     """.strip()


### PR DESCRIPTION
Changes the release notes header from:

> Changes since v0.14.0b1:

to:

> Changes since [v0.14.0b1](https://github.com/ActivityWatch/activitywatch/releases/tag/v0.14.0b1):

so releases chain together, complementing the **Full Changelog** compare link at the bottom (`build_changelog.py` already had `org`/`repo` in scope). Uses the canonical `/releases/tag/` URL form.