### PR TITLE
fix(release): patch actual Research Edition config shape

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,13 +351,7 @@ jobs:
 
       - name: Patch research edition defaults
         if: env.AW_RESEARCH_EDITION == 'true'
-        run: |
-          config=aw-watcher-window/aw_watcher_window/config.py
-          grep -q '^research_enabled = false$' "$config"
-          sed -i.bak 's/^research_enabled = false$/research_enabled = true/' "$config"
-          rm "$config.bak"
-          grep -q '^research_enabled = true$' "$config"
-          python3 scripts/patch_research_edition_config.py "$config"
+        run: python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
 
       - name: Build
         run: |
@@ -589,13 +583,7 @@ jobs:
 
       - name: Patch research edition defaults
         if: env.AW_RESEARCH_EDITION == 'true'
-        run: |
-          config=aw-watcher-window/aw_watcher_window/config.py
-          grep -q '^research_enabled = false$' "$config"
-          sed -i.bak 's/^research_enabled = false$/research_enabled = true/' "$config"
-          rm "$config.bak"
-          grep -q '^research_enabled = true$' "$config"
-          python3 scripts/patch_research_edition_config.py "$config"
+        run: python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
 
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4

--- a/scripts/patch_research_edition_config.py
+++ b/scripts/patch_research_edition_config.py
@@ -641,7 +641,7 @@ CATEGORY_MAP: list[tuple[str, str]] = [
 ]
 
 
-def build_toml_inline_table(entries: list[tuple[str, str]]) -> str:
+def build_toml_table(entries: list[tuple[str, str]]) -> str:
     seen: dict[str, str] = {}
     for pattern, category in entries:
         if pattern not in seen:
@@ -651,7 +651,22 @@ def build_toml_inline_table(entries: list[tuple[str, str]]) -> str:
         k = pattern.replace("\\", "\\\\").replace('"', '\\"')
         v = category.replace("\\", "\\\\").replace('"', '\\"')
         items.append(f'"{k}" = "{v}"')
-    return "{" + ", ".join(items) + "}"
+    return "\n".join(items)
+
+
+def patch_config(text: str) -> str:
+    enabled_line = "research_enabled = false"
+    category_header = "[aw-watcher-window.research_category_map]"
+    if enabled_line not in text:
+        raise ValueError(f"'{enabled_line}' not found")
+    if text.count(category_header) != 1:
+        raise ValueError(f"expected exactly one '{category_header}' section")
+
+    entries = build_toml_table(CATEGORY_MAP)
+    return (
+        text.replace(enabled_line, "research_enabled = true", 1)
+        .replace(category_header, f"{category_header}\n{entries}", 1)
+    )
 
 
 def main() -> None:
@@ -659,12 +674,12 @@ def main() -> None:
         print(f"Error: {CONFIG_FILE} not found", file=sys.stderr)
         sys.exit(1)
     text = CONFIG_FILE.read_text(encoding="utf-8")
-    old_line = "research_category_map = {}"
-    if old_line not in text:
-        print(f"Error: '{old_line}' not found in {CONFIG_FILE}", file=sys.stderr)
+    try:
+        patched = patch_config(text)
+    except ValueError as error:
+        print(f"Error: {error} in {CONFIG_FILE}", file=sys.stderr)
         sys.exit(1)
-    table = build_toml_inline_table(CATEGORY_MAP)
-    CONFIG_FILE.write_text(text.replace(old_line, f"research_category_map = {table}", 1), encoding="utf-8")
+    CONFIG_FILE.write_text(patched, encoding="utf-8")
     unique = len({p for p, _ in CATEGORY_MAP})
     cats = len({c for _, c in CATEGORY_MAP})
     print(f"Injected {unique} unique patterns across {cats} categories into {CONFIG_FILE}")

--- a/scripts/tests/test_patch_research_edition_config.py
+++ b/scripts/tests/test_patch_research_edition_config.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "patch_research_edition_config.py"
+SPEC = importlib.util.spec_from_file_location("patch_research_edition_config", SCRIPT)
+assert SPEC and SPEC.loader
+patcher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patcher)
+
+
+def test_patch_config_matches_watcher_config_shape():
+    source = '''default_config = """
+[aw-watcher-window]
+research_enabled = false
+
+[aw-watcher-window.research_category_map]
+""".strip()
+'''
+
+    result = patcher.patch_config(source)
+
+    assert "research_enabled = true" in result
+    assert "research_enabled = false" not in result
+    assert '[aw-watcher-window.research_category_map]\n"svenskaspel.se" = "Sensitive / Excluded"' in result
+    assert '"kagi" = "Search & Navigation"\n""".strip()' in result
+
+
+def test_patch_config_fails_closed_without_category_section():
+    with pytest.raises(ValueError, match="research_category_map"):
+        patcher.patch_config("research_enabled = false\n")


### PR DESCRIPTION
## Summary

Fixes the Research Edition manual build failure reported in [run 30396390233](https://github.com/ActivityWatch/activitywatch/actions/runs/30396390233).

The merged workflow expected a synthetic `research_category_map = {}` assignment. The actual watcher config merged in ActivityWatch/aw-watcher-window#130 uses an empty TOML table:

```toml
[aw-watcher-window.research_category_map]
```

The patcher now handles that real config shape, enables Research Edition itself, and inserts the category entries under the table header. Both build jobs call the single fail-closed patcher instead of partially editing the file first.

## Verification

- `python3 -m pytest scripts/tests/test_patch_research_edition_config.py -q` — 2 passed
- Applied the patcher to `aw-watcher-window` merge commit `a121b81` and verified `research_enabled = true` plus 570 category entries
- `git diff --check`

## Follow-up required after merge

The parent repo currently pins `aw-watcher-window` at `c9732d5`, before #130. The automatic submodule update must land (or the pointer must be updated manually) before rerunning the Research Edition workflow; otherwise this fix will correctly fail closed because the pinned watcher has no research config yet.

Follow-up to #1374.
