### PR TITLE
Fix AppImage crash on startup on newer Linux distros

### DIFF
--- a/scripts/package/package-appimage.sh
+++ b/scripts/package/package-appimage.sh
@@ -5,6 +5,15 @@
 ZIP_FILE=`ls ./dist/ -1 | grep zip | sort -r | head -1`
 unzip ./dist/$ZIP_FILE
 
+# Remove the bundled libwayland-client so the host's copy is used instead.
+# The bundled one is older than the bundled Qt Wayland plugin, which made
+# aw-qt crash on startup on newer distros with:
+#   libQt6WaylandClient.so.6: undefined symbol: wl_proxy_marshal_flags
+# (wl_proxy_marshal_flags was added in libwayland 1.20). libwayland-client is
+# meant to come from the host anyway, so dropping it from the bundle is safe.
+# See https://github.com/ActivityWatch/activitywatch/issues/939
+find activitywatch -name 'libwayland-client.so*' -delete
+
 # fetch deps
 wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
 chmod +x linuxdeploy-x86_64.AppImage


### PR DESCRIPTION
On newer Linux distros the AppImage crashes right after starting with:

    /tmp/.mount_xxxx/aw-qt: symbol lookup error: /tmp/.mount_xxxx/libQt6WaylandClient.so.6: undefined symbol: wl_proxy_marshal_flags

The reason is that the AppImage bundles its own copy of libwayland-client that is older than the bundled Qt Wayland plugin. The wl_proxy_marshal_flags symbol was only added in libwayland 1.20, so when the newer Qt plugin tries to load against the older bundled library the lookup fails and aw-qt exits.

libwayland-client is one of the libraries that is supposed to come from the host rather than be shipped inside an AppImage. This change removes it from the AppDir before the AppImage is built, so the system copy is used at runtime. On the affected distros (KDE Plasma 6 / Wayland, recent Ubuntu and Arch) the host libwayland is new enough to have the symbol. On systems without a suitable Wayland library Qt falls back to the X11 (xcb) plugin, which does not touch libwayland-client, so nothing is lost there.

A user in the linked issue reached the same conclusion and confirmed that removing the bundled Qt/Wayland libraries lets the app start.

I could not build the AppImage locally to test this end to end, so it would be good to confirm it in a release build. The deb package looks like it has the same problem and probably needs the same treatment, but I kept this change limited to the AppImage since that is what the issue is about.

Fixes #939