### PR TITLE
fix(package): exclude bundled Wayland client from all Qt packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,12 @@ endif
 # Remove problem-causing binaries
 	rm -f dist/activitywatch/libdrm.so.2       # see: https://github.com/ActivityWatch/activitywatch/issues/161
 	rm -f dist/activitywatch/libharfbuzz.so.0  # see: https://github.com/ActivityWatch/activitywatch/issues/660#issuecomment-959889230
+ifeq ($(shell uname),Linux)
+# PyInstaller's Qt bundle may include an older Wayland client than Qt requires.
+# All portable Linux packages are built from this directory, so remove it here
+# and use the distro library instead. See: https://github.com/ActivityWatch/activitywatch/issues/939
+	find dist/activitywatch -name 'libwayland-client.so*' -delete
+endif
 # These should be provided by the distro itself
 # Had to be removed due to otherwise causing the error:
 #   aw-qt: symbol lookup error: /opt/activitywatch/libQt5XcbQpa.so.5: undefined symbol: FT_Get_Font_Format

--- a/scripts/package/package-appimage.sh
+++ b/scripts/package/package-appimage.sh
@@ -5,15 +5,6 @@
 ZIP_FILE=`ls ./dist/ -1 | grep zip | sort -r | head -1`
 unzip ./dist/$ZIP_FILE
 
-# Remove the bundled libwayland-client so the host's copy is used instead.
-# The bundled one is older than the bundled Qt Wayland plugin, which made
-# aw-qt crash on startup on newer distros with:
-#   libQt6WaylandClient.so.6: undefined symbol: wl_proxy_marshal_flags
-# (wl_proxy_marshal_flags was added in libwayland 1.20). libwayland-client is
-# meant to come from the host anyway, so dropping it from the bundle is safe.
-# See https://github.com/ActivityWatch/activitywatch/issues/939
-find activitywatch -name 'libwayland-client.so*' -delete
-
 # fetch deps
 wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
 chmod +x linuxdeploy-x86_64.AppImage


### PR DESCRIPTION
## Summary

- move the Qt Wayland client exclusion from the AppImage-only staging step to the shared Qt package staging directory
- apply the fix to the portable zip and `.deb` as well as the AppImage
- keep non-Linux packages unchanged

## Why

ActivityWatch/activitywatch#1376 fixed the AppImage, but the same PyInstaller output feeds every Qt package. The linked report in ActivityWatch/activitywatch#939 confirms the `.deb` shipped the same incompatible `libwayland-client.so.0` and crashed with the same `wl_proxy_marshal_flags` error.

The release flow is:

```txt
make package → dist/activitywatch → zip
                              ↘ AppImage (unpacks zip)
                              ↘ deb (copies dist/activitywatch)
```

Removing the library in `make package`, before `package-all.sh`, fixes all three Qt Linux formats once instead of patching each packager independently. Tauri artifacts use their own bundler and do not contain this PyInstaller Qt payload, so they are intentionally unchanged.

## Verification

- `git diff --check`
- `bash -n scripts/package/package-appimage.sh scripts/package/package-deb.sh`
- `make -n package SKIP_WEBUI=true SKIP_SERVER_RUST=true` confirms cleanup precedes `package-all.sh`
- fixture check confirms nested `libwayland-client.so*` files are removed while `libQt6WaylandClient.so.6` remains
- PR quality gate: 100/100

Follow-up to ActivityWatch/activitywatch#1376.
