### PR TITLE
fix(release): make edition=research produce -research suffixed tags and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -844,3 +844,4 @@ jobs:
           prerelease: ${{ !(steps.version.outputs.is_stable == 'true') }}
 
 # Retry CI after transient upload-artifact timeout.
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -753,13 +753,22 @@ jobs:
           # so derive the range end from the tag name directly. Research
           # releases are never stable.
           LAST_RELEASE=$(STABLE_ONLY=false ./scripts/get_latest_release.sh)
+          # get_latest_release.sh only matches standard tags; if a previous
+          # research tag is newer, use it as the range base so back-to-back
+          # research releases don't repeat already-released changes.
+          prev_research=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags \
+            | grep -E -- '-research$' | grep -vx "${GITHUB_REF_NAME}" | tail -n1 || true)
+          if [ -n "$LAST_RELEASE" ] && [ -n "$prev_research" ] && \
+             git merge-base --is-ancestor "$LAST_RELEASE" "$prev_research"; then
+            LAST_RELEASE="$prev_research"
+          fi
           ./scripts/build_changelog.py --range "$LAST_RELEASE...${GITHUB_REF_NAME}"
 
       - name: Rename
         run: |
           mv changelog.md release_notes.md
 
-      - name: Add research edition banner
+      - name: Adjust release notes for research edition
         if: endsWith(github.ref_name, '-research')
         run: |
           {
@@ -770,6 +779,28 @@ jobs:
             cat release_notes.md
           } > release_notes_research.md
           mv release_notes_research.md release_notes.md
+          # The generated Downloads section hardcodes standard-edition asset
+          # filenames, which do not exist on research releases (research
+          # artifacts carry a research-edition suffix). Point at the asset
+          # list instead of linking to 404s.
+          python3 - <<'PY'
+          import re
+
+          path = "release_notes.md"
+          notes = open(path).read()
+          notes = re.sub(
+              r"(?m)^ - \[\*\*(Windows|macOS|Linux)\*\*\]\([^)]*\)[^\n]*\n?",
+              "",
+              notes,
+          )
+          notes = notes.replace(
+              "# Downloads\n",
+              "# Downloads\n\nResearch Edition installers are attached to this"
+              " release as assets below (filenames contain `research`)."
+              " Standard-release download links do not apply to this build.\n",
+          )
+          open(path, "w").write(notes)
+          PY
 
       - name: Upload release notes
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -755,11 +755,18 @@ jobs:
           # so derive the range end from the tag name directly. Research
           # releases are never stable.
           LAST_RELEASE=$(STABLE_ONLY=false ./scripts/get_latest_release.sh)
-          # get_latest_release.sh only matches standard tags; if a previous
+          # get_latest_release.sh only matches standard tags; if an ancestral
           # research tag is newer, use it as the range base so back-to-back
-          # research releases don't repeat already-released changes.
-          prev_research=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags \
-            | grep -E -- '-research$' | grep -vx "${GITHUB_REF_NAME}" | tail -n1 || true)
+          # research releases don't repeat already-released changes. Ignore
+          # research tags from newer or unrelated release lineages.
+          prev_research=""
+          while IFS= read -r candidate; do
+            if [ "$candidate" != "${GITHUB_REF_NAME}" ] && \
+               git merge-base --is-ancestor "$candidate" "${GITHUB_REF_NAME}"; then
+              prev_research="$candidate"
+            fi
+          done < <(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags \
+            | grep -E -- '-research$' || true)
           if [ -n "$LAST_RELEASE" ] && [ -n "$prev_research" ] && \
              git merge-base --is-ancestor "$LAST_RELEASE" "$prev_research"; then
             LAST_RELEASE="$prev_research"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -755,18 +755,12 @@ jobs:
           # so derive the range end from the tag name directly. Research
           # releases are never stable.
           LAST_RELEASE=$(STABLE_ONLY=false ./scripts/get_latest_release.sh)
-          # get_latest_release.sh only matches standard tags; if an ancestral
-          # research tag is newer, use it as the range base so back-to-back
-          # research releases don't repeat already-released changes. Ignore
-          # research tags from newer or unrelated release lineages.
-          prev_research=""
-          while IFS= read -r candidate; do
-            if [ "$candidate" != "${GITHUB_REF_NAME}" ] && \
-               git merge-base --is-ancestor "$candidate" "${GITHUB_REF_NAME}"; then
-              prev_research="$candidate"
-            fi
-          done < <(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags \
-            | grep -E -- '-research$' || true)
+          # get_latest_release.sh only matches standard tags; use git describe
+          # to find the topologically nearest ancestral research release.
+          # Excluding the current tag also ignores newer or unrelated lineages.
+          prev_research=$(git describe --tags --abbrev=0 \
+            --match '*-research' --exclude "${GITHUB_REF_NAME}" \
+            "${GITHUB_REF_NAME}" 2>/dev/null || true)
           if [ -n "$LAST_RELEASE" ] && [ -n "$prev_research" ] && \
              git merge-base --is-ancestor "$LAST_RELEASE" "$prev_research"; then
             LAST_RELEASE="$prev_research"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,17 +117,11 @@ jobs:
           fi
 
           prerelease_pattern="^v${next_base//./\\.}b[0-9]+$"
-          if [ "$EDITION" = "research" ]; then
-            # Research tags share the bN counter with standard tags so the same
-            # bN number never refers to two different builds.
-            prerelease_pattern="^v${next_base//./\\.}b[0-9]+(-research)?$"
-          fi
           last_prerelease=$(git tag --sort=-version:refname | grep -E "$prerelease_pattern" | head -1 || true)
 
           if [ -n "$last_prerelease" ]; then
             since_ref="$last_prerelease"
             last_prerelease_num=${last_prerelease##*b}
-            last_prerelease_num=${last_prerelease_num%-research}
             next_tag="v${next_base}b$((last_prerelease_num + 1))"
           else
             since_ref="$latest_stable"
@@ -135,10 +129,18 @@ jobs:
           fi
 
           if [ "$EDITION" = "research" ]; then
-            # Make research prereleases unmistakable: suffixed tag, so the
-            # tag-triggered build knows to produce research-edition artifacts
-            # and the release can never be confused with a standard release.
-            next_tag="${next_tag}-research"
+            # A research release is the current standard prerelease lineage
+            # with an edition suffix. It must not consume the next standard bN.
+            if [ -n "$last_prerelease" ]; then
+              next_tag="${last_prerelease}-research"
+            else
+              next_tag="${next_tag}-research"
+            fi
+            if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
+              echo "Research tag $next_tag already exists; skipping duplicate release."
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           commits_since_ref=$(git rev-list "${since_ref}..HEAD" --count)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_LINE: ${{ github.event.inputs.release_line || 'patch' }}
+          EDITION: ${{ github.event.inputs.edition || 'standard' }}
         run: |
           set -euo pipefail
 
@@ -116,15 +117,28 @@ jobs:
           fi
 
           prerelease_pattern="^v${next_base//./\\.}b[0-9]+$"
+          if [ "$EDITION" = "research" ]; then
+            # Research tags share the bN counter with standard tags so the same
+            # bN number never refers to two different builds.
+            prerelease_pattern="^v${next_base//./\\.}b[0-9]+(-research)?$"
+          fi
           last_prerelease=$(git tag --sort=-version:refname | grep -E "$prerelease_pattern" | head -1 || true)
 
           if [ -n "$last_prerelease" ]; then
             since_ref="$last_prerelease"
             last_prerelease_num=${last_prerelease##*b}
+            last_prerelease_num=${last_prerelease_num%-research}
             next_tag="v${next_base}b$((last_prerelease_num + 1))"
           else
             since_ref="$latest_stable"
             next_tag="v${next_base}b1"
+          fi
+
+          if [ "$EDITION" = "research" ]; then
+            # Make research prereleases unmistakable: suffixed tag, so the
+            # tag-triggered build knows to produce research-edition artifacts
+            # and the release can never be confused with a standard release.
+            next_tag="${next_tag}-research"
           fi
 
           commits_since_ref=$(git rev-list "${since_ref}..HEAD" --count)
@@ -217,12 +231,19 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.preflight.outputs.next_tag }}"
-          git tag -a "$tag" -m "Development prerelease $tag"
+          msg="Development prerelease $tag"
+          if [[ "$tag" == *-research ]]; then
+            msg="Development prerelease $tag (research edition)"
+          fi
+          git tag -a "$tag" -m "$msg"
           git push origin "$tag"
           {
             echo "## Dev release created"
             echo ""
             echo "- Tag: \`$tag\`"
+            if [[ "$tag" == *-research ]]; then
+              echo "- Edition: research"
+            fi
             echo "- Changes since: \`${{ needs.preflight.outputs.since_ref }}\`"
             echo "- Commits: \`${{ needs.preflight.outputs.commits_since_ref }}\`"
             echo ""
@@ -237,7 +258,7 @@ jobs:
     env:
       AW_EXTRAS: true
       MACOSX_DEPLOYMENT_TARGET: "12.0"
-      AW_RESEARCH_EDITION: ${{ github.event_name == 'workflow_dispatch' && inputs.edition == 'research' }}
+      AW_RESEARCH_EDITION: ${{ (github.event_name == 'workflow_dispatch' && inputs.edition == 'research') || endsWith(github.ref_name, '-research') }}
     defaults:
       run:
         shell: bash
@@ -458,7 +479,7 @@ jobs:
       AW_EXTRAS: true
       TAURI_BUILD: true
       MACOSX_DEPLOYMENT_TARGET: "12.0"
-      AW_RESEARCH_EDITION: ${{ github.event_name == 'workflow_dispatch' && inputs.edition == 'research' }}
+      AW_RESEARCH_EDITION: ${{ (github.event_name == 'workflow_dispatch' && inputs.edition == 'research') || endsWith(github.ref_name, '-research') }}
       # All subprojects share one virtualenv. Poetry's parallel installer can
       # race while replacing the same dependency from different lock files.
       POETRY_INSTALLER_PARALLEL: "false"
@@ -720,13 +741,35 @@ jobs:
           pip install requests
 
       - name: Generate release notes
+        if: ${{ !endsWith(github.ref_name, '-research') }}
         run: |
           LAST_RELEASE=`STABLE_ONLY=${{ steps.version.outputs.is_stable }} ./scripts/get_latest_release.sh`
           ./scripts/build_changelog.py --range "$LAST_RELEASE...${{ steps.version.outputs.full }}"
 
+      - name: Generate release notes (research edition)
+        if: endsWith(github.ref_name, '-research')
+        run: |
+          # check-version-format-action cannot parse research-suffixed tags,
+          # so derive the range end from the tag name directly. Research
+          # releases are never stable.
+          LAST_RELEASE=$(STABLE_ONLY=false ./scripts/get_latest_release.sh)
+          ./scripts/build_changelog.py --range "$LAST_RELEASE...${GITHUB_REF_NAME}"
+
       - name: Rename
         run: |
           mv changelog.md release_notes.md
+
+      - name: Add research edition banner
+        if: endsWith(github.ref_name, '-research')
+        run: |
+          {
+            echo "> [!IMPORTANT]"
+            echo "> **ActivityWatch Research Edition** (\`${GITHUB_REF_NAME}\`) — prerelease build for research-study participants, with the privacy filter and study category map enabled by default (\`research_enabled = true\` in aw-watcher-window)."
+            echo "> Not intended for general use — regular users should install the latest [standard release](https://github.com/ActivityWatch/activitywatch/releases) instead."
+            echo ""
+            cat release_notes.md
+          } > release_notes_research.md
+          mv release_notes_research.md release_notes.md
 
       - name: Upload release notes
         uses: actions/upload-artifact@v7
@@ -758,8 +801,12 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           draft: true
+          # Empty name falls back to the tag name (standard releases unchanged).
+          name: ${{ endsWith(github.ref_name, '-research') && format('{0} (Research Edition)', github.ref_name) || '' }}
           files: dist/*/activitywatch-*.*
           body_path: dist/release_notes/release_notes.md
+          # check-version-format-action leaves is_stable unset/false for
+          # research-suffixed tags, so this stays prerelease for them too.
           prerelease: ${{ !(steps.version.outputs.is_stable == 'true') }}
 
 # Retry CI after transient upload-artifact timeout.


### PR DESCRIPTION
## Problem

Dispatching the Release workflow with `edition=research` (run [30542890580](https://github.com/ActivityWatch/activitywatch/actions/runs/30542890580)) produced a **standard-looking tag** (`v0.14.0b4`) — and worse, a standard-built release:

- `create-tag` pushes a plain `vX.Y.ZbN` tag with no research marker.
- The **tag-push run** is the one that publishes the draft release, and there `AW_RESEARCH_EDITION` evaluated to `false` (it was gated on `workflow_dispatch && inputs.edition == 'research'`), so the config patch never ran for the artifacts that actually get released. The research-patched artifacts from the dispatch run itself are only uploaded as workflow artifacts and never released.

So the "research" release was indistinguishable from — and identical to — a standard release.

## Fix

When `edition=research`, flow the edition through the **tag name**:

- **preflight**: computed tag becomes `<latest-standard-tag>-research` (for example, `v0.14.0b4-research` alongside `v0.14.0b4`). Research dispatches do not consume the next standard `bN`; an already-existing research tag is a clean no-op. Standard preflight ignores research tags entirely.
- **build-qt / build-tauri**: `AW_RESEARCH_EDITION` is now also true when the tag ends in `-research`, so the tag-push run patches the config (`scripts/patch_research_edition_config.py`) and produces research artifacts. Filenames pick up both the tag suffix (via `VERSION_WITH_V`) and the existing `-research-edition` suffix from `package-all.sh` / the dmg/AppImage/deb renames — unmistakable.
- **release-notes**: research tags get their own changelog step (range end derived from `GITHUB_REF_NAME`, since `check-version-format-action` can't parse the suffix and would emit an empty `full`), plus an `[!IMPORTANT]` Research Edition banner prepended to the notes.
- **release**: draft is titled `vX.Y.ZbN-research (Research Edition)`; `prerelease` stays true (is_stable is unset/false for research tags). Standard releases keep the default tag-name title (empty `name` falls back to the tag).

Standard-edition behavior is unchanged — every new branch is behind an edition/tag-suffix conditional (verified by simulating the preflight numbering against the real tag list for standard and research scenarios).

## Notes

- The `v0.14.0b4` mis-tag itself is left to Erik to delete/re-release; this PR only prevents recurrence.
- The macos-15-intel Qt failure in run 30542890580 was a runner network flake during notarization staple (`NSURLErrorDomain -1009` against appstoreconnect.apple.com) — retry is fine, nothing to fix in the workflow.
- Known edge case (unchanged from before): the `highest_prerelease` release-line-continuation check only looks at standard tags, so a research dispatch on a brand-new release line that only has research prereleases would restart from the stable bump. Considered out of scope.

