### PR TITLE
fix(release): consistent release asset naming across editions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,10 @@ jobs:
       - name: Determine and output version
         run: |
           VERSION_WITH_V=$(bash scripts/package/getversion.sh)
+          # Strip the research tag suffix for filenames: the edition gets its
+          # own token (activitywatch[-tauri][-research]-<version>-...), so the
+          # version part stays a plain version.
+          VERSION_WITH_V="${VERSION_WITH_V%-research}"
           VERSION_NO_V="${VERSION_WITH_V#v}"
           echo "VERSION_WITH_V=${VERSION_WITH_V}" >> "$GITHUB_ENV"
           echo "========================================"
@@ -437,9 +441,9 @@ jobs:
 
             make dist/notarize
           fi
-          EDITION_SUFFIX=""
-          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then EDITION_SUFFIX="-research-edition"; fi
-          mv dist/ActivityWatch.dmg dist/activitywatch-${VERSION_WITH_V}-macos-$(uname -m)${EDITION_SUFFIX}.dmg
+          EDITION=""
+          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then EDITION="-research"; fi
+          mv dist/ActivityWatch.dmg dist/activitywatch${EDITION}-${VERSION_WITH_V}-macos-$(uname -m).dmg
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
@@ -450,21 +454,11 @@ jobs:
 
       - name: Package AppImage
         if: startsWith(runner.os, 'linux')
-        run: |
-          ./scripts/package/package-appimage.sh
-          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then
-            mv dist/activitywatch-linux-x86_64.AppImage \
-              dist/activitywatch-linux-x86_64-research-edition.AppImage
-          fi
+        run: ./scripts/package/package-appimage.sh
 
       - name: Package deb
         if: startsWith(runner.os, 'linux')
-        run: |
-          ./scripts/package/package-deb.sh
-          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then
-            deb="dist/activitywatch-${VERSION_WITH_V}-linux-x86_64.deb"
-            mv "$deb" "${deb%.deb}-research-edition.deb"
-          fi
+        run: ./scripts/package/package-deb.sh
 
       - name: Upload packages
         uses: actions/upload-artifact@v7
@@ -525,6 +519,10 @@ jobs:
       - name: Determine and output version
         run: |
           VERSION_WITH_V=$(bash scripts/package/getversion.sh)
+          # Strip the research tag suffix for filenames: the edition gets its
+          # own token (activitywatch[-tauri][-research]-<version>-...), so the
+          # version part stays a plain version.
+          VERSION_WITH_V="${VERSION_WITH_V%-research}"
           VERSION_NO_V="${VERSION_WITH_V#v}"
           echo "VERSION_WITH_V=${VERSION_WITH_V}" >> "$GITHUB_ENV"
           echo "========================================"
@@ -669,13 +667,13 @@ jobs:
           # `dist/activitywatch-*.*` upload pattern below.
           ARCH=$(uname -m)
           shopt -s nullglob
-          EDITION_SUFFIX=""
-          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then EDITION_SUFFIX="-research-edition"; fi
+          EDITION=""
+          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then EDITION="-research"; fi
           for ext in AppImage deb rpm; do
             files=( dist/activitywatch/aw-tauri/*.${ext} )
             case ${#files[@]} in
               0) continue ;;
-              1) cp -v "${files[0]}" "dist/activitywatch-tauri-${VERSION_WITH_V}-linux-${ARCH}${EDITION_SUFFIX}.${ext}" ;;
+              1) cp -v "${files[0]}" "dist/activitywatch-tauri${EDITION}-${VERSION_WITH_V}-linux-${ARCH}.${ext}" ;;
               *) echo "ERROR: expected at most 1 .${ext} bundle, found ${#files[@]}" >&2; exit 1 ;;
             esac
           done
@@ -700,9 +698,9 @@ jobs:
 
             make dist/notarize
           fi
-          EDITION_SUFFIX=""
-          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then EDITION_SUFFIX="-research-edition"; fi
-          mv dist/ActivityWatch.dmg dist/activitywatch-tauri-${VERSION_WITH_V}-macos-$(uname -m)${EDITION_SUFFIX}.dmg
+          EDITION=""
+          if [[ "$AW_RESEARCH_EDITION" == "true" ]]; then EDITION="-research"; fi
+          mv dist/ActivityWatch.dmg dist/activitywatch-tauri${EDITION}-${VERSION_WITH_V}-macos-$(uname -m).dmg
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
@@ -784,7 +782,7 @@ jobs:
           mv release_notes_research.md release_notes.md
           # The generated Downloads section hardcodes standard-edition asset
           # filenames, which do not exist on research releases (research
-          # artifacts carry a research-edition suffix). Point at the asset
+          # artifacts carry a -research token). Point at the asset
           # list instead of linking to 404s.
           python3 - <<'PY'
           import re

--- a/scripts/package/package-all.sh
+++ b/scripts/package/package-all.sh
@@ -48,12 +48,17 @@ platform=$(get_platform)
 version=$(get_version)
 version_no_prefix=$(get_version_no_prefix)
 arch=$(get_arch)
+# Research tags are suffixed (e.g. v0.14.0b3-research), but the edition
+# belongs in its own filename token, not in the version part:
+#   activitywatch[-tauri][-research]-<version>-<os>-<arch>[-setup].<ext>
+version="${version%-research}"
+version_no_prefix="${version_no_prefix%-research}"
 build_suffix=""
 if [[ $TAURI_BUILD == "true" ]]; then
     build_suffix="-tauri"
 fi
 if [[ $AW_RESEARCH_EDITION == "true" ]]; then
-    build_suffix="${build_suffix}-research-edition"
+    build_suffix="${build_suffix}-research"
 fi
 
 echo "========================================"

--- a/scripts/package/package-appimage.sh
+++ b/scripts/package/package-appimage.sh
@@ -20,4 +20,11 @@ chmod a+x ./activitywatch/AppRun
 # build appimage
 ./linuxdeploy-x86_64.AppImage --appdir activitywatch --executable ./activitywatch/aw-qt --output appimage --desktop-file ./activitywatch/aw-qt.desktop --icon-file ./activitywatch/media/logo/logo.png --icon-filename activitywatch
 APPIMAGE_FILE=`ls -1 | grep AppImage| grep -i ActivityWatch`
-cp -v $APPIMAGE_FILE ./dist/activitywatch-linux-x86_64.AppImage
+# Deliberately unversioned: the AppImage has kept this exact name across
+# releases so the stable download URL keeps working, e.g.
+# https://github.com/ActivityWatch/activitywatch/releases/latest/download/activitywatch-linux-x86_64.AppImage
+EDITION=""
+if [[ $AW_RESEARCH_EDITION == "true" ]]; then
+    EDITION="-research"
+fi
+cp -v $APPIMAGE_FILE ./dist/activitywatch${EDITION}-linux-x86_64.AppImage

--- a/scripts/package/package-deb.sh
+++ b/scripts/package/package-deb.sh
@@ -7,7 +7,14 @@ set -x
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION="$("$SCRIPT_DIR/getversion.sh")"
+# Strip the research tag suffix: the edition gets its own filename token, and
+# a bare "-research" in the Debian version field would parse as a revision.
+VERSION="${VERSION%-research}"
 VERSION_NUM="$(echo "$VERSION" | sed -e 's/^v//')"
+EDITION=""
+if [[ $AW_RESEARCH_EDITION == "true" ]]; then
+    EDITION="-research"
+fi
 echo "Version (with v): $VERSION"
 echo "Version (without v): $VERSION_NUM"
 PKGDIR="activitywatch_$VERSION_NUM"
@@ -51,4 +58,4 @@ sudo cp $PKGDIR/opt/activitywatch/aw-qt.desktop $PKGDIR/etc/xdg/autostart/
 sudo cp $PKGDIR/opt/activitywatch/aw-qt.desktop $PKGDIR/usr/share/applications/
 
 dpkg-deb --build $PKGDIR
-sudo mv activitywatch_${VERSION_NUM}.deb dist/activitywatch-${VERSION}-linux-x86_64.deb
+sudo mv activitywatch_${VERSION_NUM}.deb dist/activitywatch${EDITION}-${VERSION}-linux-x86_64.deb


### PR DESCRIPTION
## Summary

The [v0.14.0b3-research](https://github.com/ActivityWatch/activitywatch/releases/tag/v0.14.0b3-research) release assets mixed three naming conventions:

- zips/setup.exe put the edition **before** the version: `activitywatch-research-edition-v0.14.0b3-research-...`
- dmg/deb/rpm/AppImage put it **after** the arch: `...-linux-x86_64-research-edition.deb`
- the Qt AppImage had **no version at all**: `activitywatch-linux-x86_64-research-edition.AppImage`

…and all of them said "research" twice, since the tag already carries a `-research` suffix.

This unifies everything to:

```
activitywatch[-tauri][-research]-<version>-<os>-<arch>[-setup].<ext>
```

The `-research` tag suffix is stripped from the version part of filenames (the edition lives in its own token, keeping the version part a plain version). Example names for a future `v0.14.0b4-research`:

```
activitywatch-research-linux-x86_64.AppImage
activitywatch-research-v0.14.0b4-linux-x86_64.deb
activitywatch-research-v0.14.0b4-macos-arm64.dmg
activitywatch-research-v0.14.0b4-windows-x86_64-setup.exe
activitywatch-tauri-research-v0.14.0b4-linux-x86_64.AppImage
activitywatch-tauri-research-v0.14.0b4-macos-arm64.dmg
...
```

Standard-edition names are unchanged.

## Changes

- `scripts/package/package-all.sh`: strip `-research` from the version, use `-research` (not `-research-edition`) as the edition token; the stripped version also flows into the innosetup `AW_VERSION`.
- `scripts/package/package-deb.sh`: same stripping (a bare `-research` in the Debian `Version` field would parse as a Debian revision) + edition token.
- `scripts/package/package-appimage.sh`: edition token handled in the script; documented why the filename is deliberately unversioned (stable `releases/latest/download/activitywatch-linux-x86_64.AppImage` URL).
- `.github/workflows/release.yml`: strip `-research` from `VERSION_WITH_V`, new token in dmg/tauri-bundle names, and drop the post-hoc `mv` renames for AppImage/deb now that the scripts handle the edition themselves.

## Test plan

- [x] `bash -n` on all touched scripts, YAML parse of the workflow
- [x] Simulated the name construction for all four (tauri × research) combos
- [ ] Verify via a `workflow_dispatch` research build once merged