### PR TITLE
feat(research): inject APP_TO_CATEGORY map for non-browser app privacy

### DIFF
--- a/scripts/patch_research_edition_config.py
+++ b/scripts/patch_research_edition_config.py
@@ -17,8 +17,8 @@ APP_CATEGORY_MAP — non-browser app-name → study category mapping:
     classify_app() in PR #136 performs a case-insensitive exact lookup of the
     app name. Non-browser apps are replaced by their study category; unmapped
     apps become 'Excluded'. Ordering within this map is irrelevant (exact lookup).
-    Injection is non-fatal if the [aw-watcher-window.research_app_category_map]
-    section is absent (pre-PR #136 submodule pins).
+    Injection fails closed if the [aw-watcher-window.research_app_category_map]
+    section is absent, which means the submodule pin predates PR #136.
 """
 import pathlib
 import sys
@@ -764,6 +764,15 @@ def patch_config(text: str) -> tuple[str, bool]:
         raise ValueError(f"'{enabled_line}' not found")
     if text.count(category_header) != 1:
         raise ValueError(f"expected exactly one '{category_header}' section")
+    # Fail closed: a missing section means the aw-watcher-window submodule predates
+    # PR #136, so classify_app() does not exist and non-browser apps would keep
+    # their raw names. Skipping the injection there produces a green build that
+    # silently reproduces the exact bug this map fixes -- fail loudly instead.
+    if text.count(app_category_header) != 1:
+        raise ValueError(
+            f"expected exactly one '{app_category_header}' section "
+            "(requires aw-watcher-window PR #136 in the submodule pin)"
+        )
 
     entries = build_toml_table(CATEGORY_MAP)
     patched = (
@@ -771,17 +780,10 @@ def patch_config(text: str) -> tuple[str, bool]:
         .replace(category_header, f"{category_header}\n{entries}", 1)
     )
 
-    # Inject app map when the section exists (requires aw-watcher-window PR #136).
-    # Non-fatal when absent so the script stays compatible with older submodule pins.
-    app_map_injected = False
-    if app_category_header in patched:
-        if patched.count(app_category_header) != 1:
-            raise ValueError(f"expected exactly one '{app_category_header}' section")
-        app_entries = build_toml_table(list(APP_CATEGORY_MAP.items()))
-        patched = patched.replace(app_category_header, f"{app_category_header}\n{app_entries}", 1)
-        app_map_injected = True
+    app_entries = build_toml_table(list(APP_CATEGORY_MAP.items()))
+    patched = patched.replace(app_category_header, f"{app_category_header}\n{app_entries}", 1)
 
-    return patched, app_map_injected
+    return patched, True
 
 
 def main() -> None:
@@ -798,13 +800,8 @@ def main() -> None:
     unique = len({p for p, _ in CATEGORY_MAP})
     cats = len({c for _, c in CATEGORY_MAP})
     print(f"Injected {unique} unique patterns across {cats} categories into {CONFIG_FILE}")
-    if app_map_injected:
-        print(f"Injected {len(APP_CATEGORY_MAP)} app-name entries into {CONFIG_FILE}")
-    else:
-        print(
-            "Note: [aw-watcher-window.research_app_category_map] section not found — "
-            "app map not injected (requires aw-watcher-window PR #136 in submodule)"
-        )
+    assert app_map_injected  # patch_config() now fails closed rather than skipping
+    print(f"Injected {len(APP_CATEGORY_MAP)} app-name entries into {CONFIG_FILE}")
 
 
 if __name__ == "__main__":

--- a/scripts/patch_research_edition_config.py
+++ b/scripts/patch_research_edition_config.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
-"""Patch aw-watcher-window/config.py with Matthias's research edition category map.
+"""Patch aw-watcher-window/config.py with Matthias's research edition category maps.
 
 Run as part of the CI build for research edition:
     python3 scripts/patch_research_edition_config.py <path/to/config.py>
 
-classify_title() in PR #130 checks each pattern against the URL first (when
-available), then the window title. Ordering is critical: first match wins.
-Sensitive exclusions must come first. More specific domains before general
-(music.youtube.com before youtube.com). Video domains before News title keywords
-(svtplay.se domain before the "svt" title keyword).
+Two maps are injected:
+
+CATEGORY_MAP — browser URL/title substring matching:
+    classify_title() in PR #130 checks each pattern against the URL first (when
+    available), then the window title. Ordering is critical: first match wins.
+    Sensitive exclusions must come first. More specific domains before general
+    (music.youtube.com before youtube.com). Video domains before News title keywords
+    (svtplay.se domain before the "svt" title keyword).
+
+APP_CATEGORY_MAP — non-browser app-name → study category mapping:
+    classify_app() in PR #136 performs a case-insensitive exact lookup of the
+    app name. Non-browser apps are replaced by their study category; unmapped
+    apps become 'Excluded'. Ordering within this map is irrelevant (exact lookup).
+    Injection is non-fatal if the [aw-watcher-window.research_app_category_map]
+    section is absent (pre-PR #136 submodule pins).
 """
 import pathlib
 import sys
@@ -640,6 +650,96 @@ CATEGORY_MAP: list[tuple[str, str]] = [
     ("kagi", "Search & Navigation"),
 ]
 
+# App-name → study category mapping for non-browser applications.
+# Faithfully derived from Matthias Lehner's APP_TO_CATEGORY dict (classifier 2026-07-06).
+# Keys are lowercase app names (exact match, case-insensitive at runtime).
+# "Excluded" means the app is deliberately suppressed — not a lookup miss.
+APP_CATEGORY_MAP: dict[str, str] = {
+    # AI chatbots & assistants
+    "chatgpt": "AI Chatbots & Assistants",
+    "chatgpt.exe": "AI Chatbots & Assistants",
+    "claude": "AI Chatbots & Assistants",
+    "claude.exe": "AI Chatbots & Assistants",
+    "gemini": "AI Chatbots & Assistants",
+    "microsoft copilot": "AI Chatbots & Assistants",
+    "copilot": "AI Chatbots & Assistants",
+    "perplexity": "AI Chatbots & Assistants",
+    "poe": "AI Chatbots & Assistants",
+    # Work & Productivity — Microsoft Office
+    "microsoft word": "Work & Productivity",
+    "word": "Work & Productivity",
+    "winword.exe": "Work & Productivity",
+    "microsoft excel": "Work & Productivity",
+    "excel": "Work & Productivity",
+    "excel.exe": "Work & Productivity",
+    "microsoft powerpoint": "Work & Productivity",
+    "powerpoint": "Work & Productivity",
+    "powerpnt.exe": "Work & Productivity",
+    # Email — Outlook is email, not productivity
+    "microsoft outlook": "Email",
+    "outlook": "Email",
+    "outlook.exe": "Email",
+    # Work & Productivity — collaboration/notes
+    "microsoft teams": "Work & Productivity",
+    "teams": "Work & Productivity",
+    "zoom": "Work & Productivity",
+    "zoom.us": "Work & Productivity",
+    "notion": "Work & Productivity",
+    "onenote": "Work & Productivity",
+    "adobe acrobat": "Work & Productivity",
+    "acrobat": "Work & Productivity",
+    "preview": "Work & Productivity",
+    "pages": "Work & Productivity",
+    "numbers": "Work & Productivity",
+    "keynote": "Work & Productivity",
+    "libreoffice": "Work & Productivity",
+    # Email — native clients
+    "mail": "Email",
+    "thunderbird": "Email",
+    # Messaging
+    "slack": "Messaging",
+    "signal": "Messaging",
+    "telegram": "Messaging",
+    "whatsapp": "Messaging",
+    "messenger": "Messaging",
+    "discord": "Messaging",
+    # Music & Audio
+    "spotify": "Music & Audio",
+    "music": "Music & Audio",
+    "apple music": "Music & Audio",
+    # Video Streaming — media players
+    "vlc": "Video Streaming",
+    "quicktime player": "Video Streaming",
+    "netflix": "Video Streaming",
+    # Games
+    "steam": "Games",
+    "epic games launcher": "Games",
+    "battle.net": "Games",
+    "roblox": "Games",
+    "minecraft": "Games",
+    "xbox": "Games",
+    # Work & Productivity — creative/professional software
+    "photoshop": "Work & Productivity",
+    "illustrator": "Work & Productivity",
+    "indesign": "Work & Productivity",
+    "lightroom": "Work & Productivity",
+    "premiere pro": "Work & Productivity",
+    "final cut pro": "Work & Productivity",
+    "figma": "Work & Productivity",
+    "blender": "Work & Productivity",
+    "autocad": "Work & Productivity",
+    # System utilities — explicitly excluded (not a lookup miss)
+    "finder": "Excluded",
+    "explorer": "Excluded",
+    "explorer.exe": "Excluded",
+    "system settings": "Excluded",
+    "settings": "Excluded",
+    "system preferences": "Excluded",
+    "terminal": "Excluded",
+    "cmd.exe": "Excluded",
+    "powershell.exe": "Excluded",
+}
+
 
 def build_toml_table(entries: list[tuple[str, str]]) -> str:
     seen: dict[str, str] = {}
@@ -654,19 +754,34 @@ def build_toml_table(entries: list[tuple[str, str]]) -> str:
     return "\n".join(items)
 
 
-def patch_config(text: str) -> str:
+def patch_config(text: str) -> tuple[str, bool]:
+    """Patch config.py text.  Returns (patched_text, app_map_injected)."""
     enabled_line = "research_enabled = false"
     category_header = "[aw-watcher-window.research_category_map]"
+    app_category_header = "[aw-watcher-window.research_app_category_map]"
+
     if enabled_line not in text:
         raise ValueError(f"'{enabled_line}' not found")
     if text.count(category_header) != 1:
         raise ValueError(f"expected exactly one '{category_header}' section")
 
     entries = build_toml_table(CATEGORY_MAP)
-    return (
+    patched = (
         text.replace(enabled_line, "research_enabled = true", 1)
         .replace(category_header, f"{category_header}\n{entries}", 1)
     )
+
+    # Inject app map when the section exists (requires aw-watcher-window PR #136).
+    # Non-fatal when absent so the script stays compatible with older submodule pins.
+    app_map_injected = False
+    if app_category_header in patched:
+        if patched.count(app_category_header) != 1:
+            raise ValueError(f"expected exactly one '{app_category_header}' section")
+        app_entries = build_toml_table(list(APP_CATEGORY_MAP.items()))
+        patched = patched.replace(app_category_header, f"{app_category_header}\n{app_entries}", 1)
+        app_map_injected = True
+
+    return patched, app_map_injected
 
 
 def main() -> None:
@@ -675,7 +790,7 @@ def main() -> None:
         sys.exit(1)
     text = CONFIG_FILE.read_text(encoding="utf-8")
     try:
-        patched = patch_config(text)
+        patched, app_map_injected = patch_config(text)
     except ValueError as error:
         print(f"Error: {error} in {CONFIG_FILE}", file=sys.stderr)
         sys.exit(1)
@@ -683,6 +798,13 @@ def main() -> None:
     unique = len({p for p, _ in CATEGORY_MAP})
     cats = len({c for _, c in CATEGORY_MAP})
     print(f"Injected {unique} unique patterns across {cats} categories into {CONFIG_FILE}")
+    if app_map_injected:
+        print(f"Injected {len(APP_CATEGORY_MAP)} app-name entries into {CONFIG_FILE}")
+    else:
+        print(
+            "Note: [aw-watcher-window.research_app_category_map] section not found — "
+            "app map not injected (requires aw-watcher-window PR #136 in submodule)"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_patch_research_edition_config.py
+++ b/scripts/tests/test_patch_research_edition_config.py
@@ -20,12 +20,13 @@ research_enabled = false
 """.strip()
 '''
 
-    result = patcher.patch_config(source)
+    result, app_map_injected = patcher.patch_config(source)
 
     assert "research_enabled = true" in result
     assert "research_enabled = false" not in result
     assert '[aw-watcher-window.research_category_map]\n"svenskaspel.se" = "Sensitive / Excluded"' in result
     assert '"kagi" = "Search & Navigation"\n""".strip()' in result
+    assert app_map_injected is False  # source has no research_app_category_map section
 
 
 def test_patch_config_fails_closed_without_category_section():

--- a/scripts/tests/test_patch_research_edition_config.py
+++ b/scripts/tests/test_patch_research_edition_config.py
@@ -17,6 +17,8 @@ def test_patch_config_matches_watcher_config_shape():
 research_enabled = false
 
 [aw-watcher-window.research_category_map]
+
+[aw-watcher-window.research_app_category_map]
 """.strip()
 '''
 
@@ -25,10 +27,28 @@ research_enabled = false
     assert "research_enabled = true" in result
     assert "research_enabled = false" not in result
     assert '[aw-watcher-window.research_category_map]\n"svenskaspel.se" = "Sensitive / Excluded"' in result
-    assert '"kagi" = "Search & Navigation"\n""".strip()' in result
-    assert app_map_injected is False  # source has no research_app_category_map section
+    assert '[aw-watcher-window.research_app_category_map]\n"chatgpt" = "AI Chatbots & Assistants"' in result
+    assert app_map_injected is True
 
 
 def test_patch_config_fails_closed_without_category_section():
     with pytest.raises(ValueError, match="research_category_map"):
         patcher.patch_config("research_enabled = false\n")
+
+
+def test_patch_config_fails_closed_on_pre_136_submodule_pin():
+    """A pin without classify_app() must abort, not silently ship the raw app names.
+
+    Regression guard for the build that green-lit an artifact reproducing the
+    exact 'still only uncategorized' symptom the app map exists to fix.
+    """
+    source = '''default_config = """
+[aw-watcher-window]
+research_enabled = false
+
+[aw-watcher-window.research_category_map]
+""".strip()
+'''
+
+    with pytest.raises(ValueError, match="research_app_category_map"):
+        patcher.patch_config(source)


### PR DESCRIPTION
## Summary

Updates the Research Edition CI patch script to inject Matthias Lehner's **72-entry app-name → category map** into `[aw-watcher-window.research_app_category_map]`, closing the last spec gap before Matthias's September study.

Depends on [ActivityWatch/aw-watcher-window#136](https://github.com/ActivityWatch/aw-watcher-window/pull/136) being merged first (that PR adds the `research_app_category_map` config section and the runtime lookup).

## What changed

The CI patch script (`scripts/patch_research_edition_config.py`) now:

1. Defines `APP_CATEGORY_MAP` — 72 entries, faithfully derived from Matthias's `APP_TO_CATEGORY` dict (classifier 2026-07-06)
2. Injects it into `[aw-watcher-window.research_app_category_map]` when the section is present in the patched config.py
3. Falls back gracefully (non-fatal, prints a note) when the section is absent — backward-compatible with submodule pins before #136

## Effect at runtime

Once aw-watcher-window#136 merges and the submodule is bumped:
- **Non-browser apps** are replaced by a broad study category: e.g. `Microsoft Outlook → Email`, `Spotify → Music & Audio`, `steam → Games`
- **Unmapped apps** become `Excluded` (strictly more private than keeping the raw name)
- **Browser behaviour is unchanged** (URL/title → study category, as before)

This is what Matthias's classifier specifies and what he expects from the study build. It is also what was shown in his test screenshot: `Messages`, `Finder`, `Microsoft Outlook`, `Microsoft Teams` appearing as raw app names instead of study categories.

## Sequence to ship

1. Merge aw-watcher-window#136 → new Swift binary with `--research-app-category` support
2. Merge this PR
3. Bump aw-watcher-window submodule to the post-#136 commit
4. Re-trigger Research Edition build dispatch → new tag e.g. `v0.14.0b4-research`
5. Smoke-test installer, send to Matthias

Ref: [ErikBjare/bob#1108](https://github.com/ErikBjare/bob/issues/1108)