### PR TITLE
fix(research): survive the #137 config layout, and anchor the flag rewrite

### DIFF
--- a/scripts/patch_research_edition_config.py
+++ b/scripts/patch_research_edition_config.py
@@ -21,6 +21,7 @@ APP_CATEGORY_MAP — non-browser app-name → study category mapping:
     section is absent, which means the submodule pin predates PR #136.
 """
 import pathlib
+import re
 import sys
 
 CONFIG_FILE = pathlib.Path(
@@ -754,34 +755,72 @@ def build_toml_table(entries: list[tuple[str, str]]) -> str:
     return "\n".join(items)
 
 
+# The flag must be matched anchored to line start. Since aw-watcher-window #137,
+# config.py also documents the rewrite in a comment containing the literal text
+# `sed -i 's/^research_enabled = false$/research_enabled = true/'`, and that
+# comment appears *before* the real flag. An unanchored replace would patch the
+# comment and leave research_enabled = false -- a green build with the Research
+# Edition silently disabled.
+ENABLED_FLAG_RE = re.compile(r"^research_enabled = false$", re.MULTILINE)
+
+# Anchor for the post-#137 layout: research knobs moved out of `default_config`
+# into a separate template so they are not persisted into every fresh install's
+# config file.
+RESEARCH_DEFAULTS_ANCHOR = 'research_defaults = """'
+
+# Proof that the watcher can actually consume an app map (aw-watcher-window #136).
+# This is a runtime-capability check, not a layout check, so it survives further
+# reshuffling of the config templates.
+APP_MAP_RUNTIME_MARKER = 'config.get("research_app_category_map"'
+
+
 def patch_config(text: str) -> tuple[str, bool]:
     """Patch config.py text.  Returns (patched_text, app_map_injected)."""
-    enabled_line = "research_enabled = false"
     category_header = "[aw-watcher-window.research_category_map]"
     app_category_header = "[aw-watcher-window.research_app_category_map]"
 
-    if enabled_line not in text:
-        raise ValueError(f"'{enabled_line}' not found")
-    if text.count(category_header) != 1:
-        raise ValueError(f"expected exactly one '{category_header}' section")
-    # Fail closed: a missing section means the aw-watcher-window submodule predates
-    # PR #136, so classify_app() does not exist and non-browser apps would keep
-    # their raw names. Skipping the injection there produces a green build that
-    # silently reproduces the exact bug this map fixes -- fail loudly instead.
-    if text.count(app_category_header) != 1:
+    enabled_matches = len(ENABLED_FLAG_RE.findall(text))
+    if enabled_matches != 1:
         raise ValueError(
-            f"expected exactly one '{app_category_header}' section "
-            "(requires aw-watcher-window PR #136 in the submodule pin)"
+            f"expected exactly one line-anchored 'research_enabled = false', found {enabled_matches}"
+        )
+
+    # Fail closed: without the runtime lookup the submodule predates PR #136, so
+    # classify_app() does not exist and non-browser apps would keep their raw
+    # names. Injecting anyway produces a green build that silently reproduces the
+    # exact privacy bug this map fixes -- fail loudly instead.
+    if APP_MAP_RUNTIME_MARKER not in text:
+        raise ValueError(
+            "aw-watcher-window does not read research_app_category_map "
+            "(requires PR #136 in the submodule pin)"
         )
 
     entries = build_toml_table(CATEGORY_MAP)
-    patched = (
-        text.replace(enabled_line, "research_enabled = true", 1)
-        .replace(category_header, f"{category_header}\n{entries}", 1)
-    )
-
     app_entries = build_toml_table(list(APP_CATEGORY_MAP.items()))
-    patched = patched.replace(app_category_header, f"{app_category_header}\n{app_entries}", 1)
+
+    if RESEARCH_DEFAULTS_ANCHOR in text:
+        # Post-#137: the maps belong inside the `research_defaults` template.
+        # That template is parsed standalone and merged into the
+        # [aw-watcher-window] section key-by-key, so its table headers must NOT
+        # carry the section prefix.
+        block = (
+            "research_enabled = true\n\n"
+            f"[research_category_map]\n{entries}\n\n"
+            f"[research_app_category_map]\n{app_entries}"
+        )
+        patched = ENABLED_FLAG_RE.sub(lambda _: block, text, count=1)
+    else:
+        # Pre-#137: the section-prefixed headers are already present in
+        # `default_config`; inject the entries under them.
+        if text.count(category_header) != 1:
+            raise ValueError(f"expected exactly one '{category_header}' section")
+        if text.count(app_category_header) != 1:
+            raise ValueError(f"expected exactly one '{app_category_header}' section")
+        patched = ENABLED_FLAG_RE.sub("research_enabled = true", text, count=1)
+        patched = patched.replace(category_header, f"{category_header}\n{entries}", 1)
+        patched = patched.replace(
+            app_category_header, f"{app_category_header}\n{app_entries}", 1
+        )
 
     return patched, True
 

--- a/scripts/tests/test_patch_research_edition_config.py
+++ b/scripts/tests/test_patch_research_edition_config.py
@@ -1,4 +1,6 @@
+import ast
 import importlib.util
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -11,44 +13,130 @@ patcher = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(patcher)
 
 
-def test_patch_config_matches_watcher_config_shape():
-    source = '''default_config = """
+# Every real config.py reads the app map at runtime; that lookup is what the
+# patcher uses to prove the submodule pin includes aw-watcher-window#136.
+RUNTIME_LOOKUPS = """
+
+def parse_args():
+    parsed_args.research_category_map = dict(config.get("research_category_map", {}))
+    parsed_args.research_app_category_map = dict(config.get("research_app_category_map", {}))
+"""
+
+# Layout before aw-watcher-window#137: the research tables live in
+# default_config, section-prefixed.
+PRE_137 = '''default_config = """
 [aw-watcher-window]
+poll_time = 1.0
 research_enabled = false
 
 [aw-watcher-window.research_category_map]
 
 [aw-watcher-window.research_app_category_map]
 """.strip()
-'''
+''' + RUNTIME_LOOKUPS
 
-    result, app_map_injected = patcher.patch_config(source)
+# Layout since aw-watcher-window#137: research knobs moved to their own template
+# so they are not persisted into every fresh install's config, and a comment
+# documents the release-time rewrite -- including the literal flag text.
+POST_137 = '''default_config = """
+[aw-watcher-window]
+poll_time = 1.0
+""".strip()
 
-    assert "research_enabled = true" in result
-    assert "research_enabled = false" not in result
-    assert '[aw-watcher-window.research_category_map]\n"svenskaspel.se" = "Sensitive / Excluded"' in result
-    assert '[aw-watcher-window.research_app_category_map]\n"chatgpt" = "AI Chatbots & Assistants"' in result
+# The Research Edition release build rewrites the flag below with
+#   sed -i 's/^research_enabled = false$/research_enabled = true/'
+# Keep that line at column 0 and byte-identical.
+research_defaults = """
+research_enabled = false
+""".strip()
+''' + RUNTIME_LOOKUPS
+
+
+def _string_constant(source: str, name: str) -> str:
+    """Return the value of a module-level string assignment, unwrapping .strip()."""
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) == name:
+            value = node.value
+            if isinstance(value, ast.Call):  # `""" ... """.strip()`
+                value = value.func.value
+            return ast.literal_eval(value)
+    raise AssertionError(f"{name} not found")
+
+
+def test_pre_137_layout_injects_under_prefixed_headers():
+    result, app_map_injected = patcher.patch_config(PRE_137)
+
     assert app_map_injected is True
+    ast.parse(result)
+
+    section = tomllib.loads(_string_constant(result, "default_config"))["aw-watcher-window"]
+    assert section["research_enabled"] is True
+    assert section["research_category_map"]["svenskaspel.se"] == "Sensitive / Excluded"
+    assert section["research_app_category_map"]["chatgpt"] == "AI Chatbots & Assistants"
 
 
-def test_patch_config_fails_closed_without_category_section():
-    with pytest.raises(ValueError, match="research_category_map"):
-        patcher.patch_config("research_enabled = false\n")
+def test_post_137_layout_injects_into_research_defaults():
+    """The tables must land in research_defaults, with unprefixed headers.
+
+    research_defaults is parsed standalone and merged into the
+    [aw-watcher-window] section key by key, so a section-prefixed header there
+    would produce a nested `aw-watcher-window` key that nothing reads.
+    """
+    result, app_map_injected = patcher.patch_config(POST_137)
+
+    assert app_map_injected is True
+    ast.parse(result)
+
+    defaults = tomllib.loads(_string_constant(result, "research_defaults"))
+    assert "aw-watcher-window" not in defaults
+    assert defaults["research_enabled"] is True
+    assert defaults["research_category_map"]["svenskaspel.se"] == "Sensitive / Excluded"
+    assert defaults["research_app_category_map"]["chatgpt"] == "AI Chatbots & Assistants"
 
 
-def test_patch_config_fails_closed_on_pre_136_submodule_pin():
-    """A pin without classify_app() must abort, not silently ship the raw app names.
+def test_flag_rewrite_is_line_anchored_and_spares_the_sed_comment():
+    """The #137 comment contains the literal flag text, and precedes the real flag.
+
+    An unanchored replace patches the comment and leaves research_enabled = false
+    -- a green build shipping a Research Edition with research silently disabled.
+    """
+    result, _ = patcher.patch_config(POST_137)
+
+    assert "s/^research_enabled = false$/research_enabled = true/" in result
+    assert tomllib.loads(_string_constant(result, "research_defaults"))["research_enabled"] is True
+
+
+def test_fails_closed_on_pre_136_submodule_pin():
+    """A pin without the app-map lookup must abort, not ship raw app names.
 
     Regression guard for the build that green-lit an artifact reproducing the
     exact 'still only uncategorized' symptom the app map exists to fix.
     """
-    source = '''default_config = """
-[aw-watcher-window]
-research_enabled = false
-
-[aw-watcher-window.research_category_map]
-""".strip()
-'''
+    without_lookup = POST_137.replace(
+        'config.get("research_app_category_map"', 'config.get("something_else"'
+    )
 
     with pytest.raises(ValueError, match="research_app_category_map"):
-        patcher.patch_config(source)
+        patcher.patch_config(without_lookup)
+
+
+def test_fails_closed_when_flag_is_missing():
+    with pytest.raises(ValueError, match="research_enabled = false"):
+        patcher.patch_config(f'default_config = """\n[aw-watcher-window]\n"""{RUNTIME_LOOKUPS}')
+
+
+def test_fails_closed_on_ambiguous_flag():
+    """Two line-anchored flags mean an unknown layout -- refuse rather than guess."""
+    ambiguous = POST_137.replace(
+        "research_enabled = false\n", "research_enabled = false\nresearch_enabled = false\n", 1
+    )
+
+    with pytest.raises(ValueError, match="found 2"):
+        patcher.patch_config(ambiguous)
+
+
+def test_pre_137_layout_still_fails_closed_without_app_section():
+    missing_app_table = PRE_137.replace("\n[aw-watcher-window.research_app_category_map]\n", "\n")
+
+    with pytest.raises(ValueError, match="research_app_category_map"):
+        patcher.patch_config(missing_app_table)


### PR DESCRIPTION
Two defects in `scripts/patch_research_edition_config.py`, both introduced by the interaction with ActivityWatch/aw-watcher-window#137. Neither is visible today, and both fire on the next submodule bump.

#137 itself is right — moving research knobs out of `default_config` stops them being persisted into the config of every user who is not in a study. It just removes the two TOML table headers this script anchors on.

## 1. Injection breaks on the next submodule bump

`patch_config()` requires exactly one `[aw-watcher-window.research_category_map]` and one `[aw-watcher-window.research_app_category_map]` header. Past #137 neither exists, so the script aborts and the Research Edition build fails.

Verified against both revisions of `aw_watcher_window/config.py`:

| submodule sha | category header | app header |
|---|---|---|
| `a297914` (#136 merge — **the current pin**) | 1 | 1 |
| `a7690ac` (aw-watcher-window master, #137) | **0** | **0** |

So the build works today purely because the pin has not moved. Anything that advances it — including a routine dependabot submodule bump — breaks it. The fail-closed message would then misdiagnose the cause as "submodule predates #136", which is the opposite of what happened.

## 2. The flag rewrite could silently disable the Research Edition

#137 documents the release-time rewrite in a comment containing the literal text:

```
#   sed -i 's/^research_enabled = false$/research_enabled = true/'
```

That comment sits **above** the real flag. The existing unanchored `text.replace(enabled_line, ..., 1)` therefore rewrites the *comment* and leaves `research_enabled = false`.

That failure has no error and no failed step. It ships a signed Research Edition installer with the privacy filter off — to study participants. This is the one I'd want a second pair of eyes on.

## Fix

- **Both layouts handled.** Post-#137 the maps are injected into `research_defaults` with **unprefixed** headers — that template is parsed standalone and merged into the `[aw-watcher-window]` section key by key, so a prefixed header would create a nested `aw-watcher-window` key that nothing reads. Pre-#137 the existing prefixed headers are used, unchanged.
- **Flag rewrite is line-anchored** via `re.MULTILINE`, matching the contract #137's own comment documents. It refuses to proceed on anything other than exactly one match rather than guessing.
- **The pre-#136 guard now keys on the runtime lookup** `config.get("research_app_category_map"` instead of a table header. That tests the capability that actually matters — whether the watcher can consume an app map — and survives further reshuffling of the config templates.

## Verification

Against the two real `config.py` revisions, not just synthetic fixtures — both yield `research_enabled = true`, 570 category patterns, 72 app entries, and output that parses as valid Python and valid TOML.

Test suite rewritten to cover both layouts (7 tests, passing), including a regression test asserting the sed-example comment survives while the real flag flips. The previous fixtures omitted the runtime lookup that real `config.py` always has, which is why they did not catch this.

## Context

This is on the critical path for a Lund University study build promised this week. Related: aw-watcher-window#136, #137, and #1397.