### PR TITLE
feat(research): ship the study category set to the web UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,6 +415,18 @@ jobs:
         if: env.AW_RESEARCH_EDITION == 'true'
         run: python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
 
+      # The watcher rewrites `app` to a study category before storing, but
+      # aw-webui categorises client-side with its own defaults and never sees
+      # the watcher's map -- so without this the Categories panel reads
+      # "Uncategorized" while Top Applications shows the right categories.
+      # Derived from the same map as the step above, so the two cannot drift.
+      - name: Emit research edition category preset for the web UI
+        if: env.AW_RESEARCH_EDITION == 'true'
+        shell: bash
+        run: |
+          preset="$(python3 scripts/emit_research_category_preset.py)"
+          echo "AW_PRESET_CATEGORY_SETS=${preset}" >> "$GITHUB_ENV"
+
       - name: Build
         run: |
           python3 -m venv venv
@@ -675,6 +687,18 @@ jobs:
       - name: Patch research edition defaults
         if: env.AW_RESEARCH_EDITION == 'true'
         run: python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
+
+      # The watcher rewrites `app` to a study category before storing, but
+      # aw-webui categorises client-side with its own defaults and never sees
+      # the watcher's map -- so without this the Categories panel reads
+      # "Uncategorized" while Top Applications shows the right categories.
+      # Derived from the same map as the step above, so the two cannot drift.
+      - name: Emit research edition category preset for the web UI
+        if: env.AW_RESEARCH_EDITION == 'true'
+        shell: bash
+        run: |
+          preset="$(python3 scripts/emit_research_category_preset.py)"
+          echo "AW_PRESET_CATEGORY_SETS=${preset}" >> "$GITHUB_ENV"
 
       - name: Build
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4

--- a/scripts/emit_research_category_preset.py
+++ b/scripts/emit_research_category_preset.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Emit the Research Edition category preset consumed by aw-webui at build time.
+
+The watcher rewrites `app` to a study category before the event is stored
+(see patch_research_edition_config.py). aw-webui, however, categorises
+client-side with its own default regexes and never sees the watcher's map, so
+without this preset the Categories panel reads "Uncategorized" while Top
+Applications shows the correct categories -- the data is right and the UI
+disagrees with it. That is the exact symptom the Lund study reported on
+v0.14.0b3-research.
+
+aw-webui (ActivityWatch/aw-webui#936) reads a preset category set from the
+`AW_PRESET_CATEGORY_SETS` env var at build time. This script derives that
+preset from the same single source of truth as the watcher map, so the two can
+never drift:
+
+    python3 scripts/emit_research_category_preset.py > preset.json
+
+Rules match on the category name anchored to the whole value, because by the
+time aw-webui sees an event, `app` *is* the category name.
+"""
+
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+
+PRESET_ID = "research-study"
+PRESET_NAME = "Research Edition study categories"
+
+_PATCHER = pathlib.Path(__file__).with_name("patch_research_edition_config.py")
+
+
+def _load_category_source():
+    """Import the patch script without executing its CLI entry point."""
+    spec = importlib.util.spec_from_file_location("_re_patcher", _PATCHER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {_PATCHER}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_re_patcher"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_preset() -> dict:
+    source = _load_category_source()
+
+    categories = {category for _, category in source.CATEGORY_MAP}
+    categories |= set(source.APP_CATEGORY_MAP.values())
+    if not categories:
+        raise RuntimeError("no categories found -- refusing to emit an empty preset")
+
+    return {
+        "id": PRESET_ID,
+        "name": PRESET_NAME,
+        # Sorted so the same map always produces a byte-identical preset.
+        "categories": [
+            {
+                "name": [category],
+                "rule": {
+                    "type": "regex",
+                    "regex": f"^{re.escape(category)}$",
+                    "ignore_case": False,
+                },
+            }
+            for category in sorted(categories)
+        ],
+    }
+
+
+def main() -> None:
+    preset = build_preset()
+    # Compact and newline-free: this is written straight into $GITHUB_ENV,
+    # which treats a newline as the end of the value.
+    print(json.dumps([preset], separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/emit_research_category_preset.py
+++ b/scripts/emit_research_category_preset.py
@@ -23,8 +23,19 @@ time aw-webui sees an event, `app` *is* the category name.
 import importlib.util
 import json
 import pathlib
-import re
 import sys
+
+# Characters that are special to BOTH Python's `re` and JavaScript's RegExp
+# outside a character class. Escaping is deliberately restricted to these.
+#
+# `re.escape()` is not usable here: it escapes space as `\ ` and `&` as `\&`,
+# which are *invalid identity escapes* in JavaScript unicode-mode regex. Names
+# like "AI Chatbots & Assistants" then throw `Invalid escape` under `new
+# RegExp(r, "u")` -- 14 of the 18 study categories do. They happen to compile
+# today only because aw-webui builds the regex without the `u` flag, and the
+# failure would present as "categories don't show", i.e. indistinguishable from
+# the bug this preset exists to fix. Escape only what both engines agree on.
+_REGEX_METACHARACTERS = set(r"\^$.|?*+()[]{}")
 
 PRESET_ID = "research-study"
 PRESET_NAME = "Research Edition study categories"
@@ -41,6 +52,16 @@ def _load_category_source():
     sys.modules["_re_patcher"] = module
     spec.loader.exec_module(module)
     return module
+
+
+def escape_portable(value: str) -> str:
+    """Escape `value` so the result is a literal in both Python and JS regex.
+
+    Portable across engines *and* across JS flag modes, unlike `re.escape()`.
+    """
+    return "".join(
+        "\\" + char if char in _REGEX_METACHARACTERS else char for char in value
+    )
 
 
 def build_preset() -> dict:
@@ -60,7 +81,7 @@ def build_preset() -> dict:
                 "name": [category],
                 "rule": {
                     "type": "regex",
-                    "regex": f"^{re.escape(category)}$",
+                    "regex": f"^{escape_portable(category)}$",
                     "ignore_case": False,
                 },
             }

--- a/scripts/tests/test_emit_research_category_preset.py
+++ b/scripts/tests/test_emit_research_category_preset.py
@@ -1,0 +1,58 @@
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+
+def _load(name: str):
+    path = Path(__file__).parents[1] / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+emitter = _load("emit_research_category_preset")
+patcher = _load("patch_research_edition_config")
+
+
+def test_preset_covers_every_category_in_the_watcher_map():
+    """Preset and watcher map must share one source, or the UI drifts from the data."""
+    expected = {c for _, c in patcher.CATEGORY_MAP} | set(patcher.APP_CATEGORY_MAP.values())
+
+    names = {c["name"][0] for c in emitter.build_preset()["categories"]}
+
+    assert names == expected
+
+
+def test_rules_match_their_own_category_and_nothing_else():
+    """By the time aw-webui sees the event, `app` IS the category name."""
+    for category in emitter.build_preset()["categories"]:
+        name = category["name"][0]
+        pattern = category["rule"]["regex"]
+
+        assert re.search(pattern, name), f"{pattern!r} does not match {name!r}"
+        assert not re.search(pattern, "Some Unrelated App")
+        assert not re.search(pattern, f"{name} extra")
+
+
+def test_regex_metacharacters_in_category_names_are_escaped():
+    """Names carry '&', '/' and '-'; an unescaped name would be a broken rule."""
+    by_name = {c["name"][0]: c for c in emitter.build_preset()["categories"]}
+
+    assert by_name["Sensitive / Excluded"]["rule"]["regex"] == r"^Sensitive\ /\ Excluded$"
+    assert re.search(by_name["Shopping - Goods"]["rule"]["regex"], "Shopping - Goods")
+
+
+def test_output_is_stable_across_runs():
+    """CI reruns must not produce a different preset from the same map."""
+    assert emitter.build_preset() == emitter.build_preset()
+
+
+def test_serialises_without_newlines_for_github_env():
+    """The value is written straight into $GITHUB_ENV, which ends at a newline."""
+    payload = json.dumps([emitter.build_preset()], separators=(",", ":"))
+
+    assert "\n" not in payload
+    assert json.loads(payload)[0]["id"] == "research-study"

--- a/scripts/tests/test_emit_research_category_preset.py
+++ b/scripts/tests/test_emit_research_category_preset.py
@@ -37,12 +37,31 @@ def test_rules_match_their_own_category_and_nothing_else():
         assert not re.search(pattern, f"{name} extra")
 
 
-def test_regex_metacharacters_in_category_names_are_escaped():
-    """Names carry '&', '/' and '-'; an unescaped name would be a broken rule."""
-    by_name = {c["name"][0]: c for c in emitter.build_preset()["categories"]}
+def test_escaping_is_portable_to_javascript_unicode_mode():
+    """`re.escape` is unusable here: it emits `\\ ` and `\\&`.
 
-    assert by_name["Sensitive / Excluded"]["rule"]["regex"] == r"^Sensitive\ /\ Excluded$"
-    assert re.search(by_name["Shopping - Goods"]["rule"]["regex"], "Shopping - Goods")
+    Those are valid in Python but are *invalid identity escapes* in JavaScript
+    unicode-mode regex, so `new RegExp(r, "u")` throws on 14 of the 18 study
+    categories. aw-webui compiles without the `u` flag today, which is the only
+    reason `re.escape` would appear to work -- and the failure would present as
+    "categories don't show", indistinguishable from the bug this preset fixes.
+    """
+    for category in emitter.build_preset()["categories"]:
+        pattern = category["rule"]["regex"]
+        escaped = {pattern[i + 1] for i, ch in enumerate(pattern[:-1]) if ch == "\\"}
+
+        assert escaped <= emitter._REGEX_METACHARACTERS, (
+            f"{pattern!r} escapes characters JavaScript rejects under the u flag"
+        )
+
+
+def test_escape_portable_still_escapes_real_metacharacters():
+    """A future category name containing a metacharacter must not become a wildcard."""
+    assert emitter.escape_portable("a.b") == r"a\.b"
+    assert emitter.escape_portable("x(y)") == r"x\(y\)"
+    assert emitter.escape_portable("Shopping - Goods") == "Shopping - Goods"
+    assert re.fullmatch(emitter.escape_portable("a.b"), "a.b")
+    assert not re.fullmatch(emitter.escape_portable("a.b"), "axb")
 
 
 def test_output_is_stable_across_runs():


### PR DESCRIPTION
## Problem

The Research Edition watcher rewrites `app` to a study category before the event is stored. aw-webui categorises **client-side** using its own default regexes and never sees the watcher's map. So the **Categories** panel reads `Uncategorized` while **Top Applications** shows the correct study categories. The data is right; the UI disagrees with it.

This is what the Lund/IIIEE study reported on `v0.14.0b3-research` — twice, on 13 and 17 August. It reads as "the build is broken" to a researcher, and no amount of watcher-side fixing changes it.

#1397 makes the stored data correct. It does **not** make the Categories panel agree, because that panel never consults the watcher config.

## What this adds

ActivityWatch/aw-webui#936 adds the consumer: a build may supply a preset category set via `AW_PRESET_CATEGORY_SETS`, activated by default **only** when the user has no stored categorization (so existing users keep their own categories). This PR wires the **producer**.

`scripts/emit_research_category_preset.py` derives the preset from the same `CATEGORY_MAP` and `APP_CATEGORY_MAP` that `patch_research_edition_config.py` injects into the watcher. One source of truth — the UI's categories cannot drift from the watcher's, which is the failure this whole class of bug comes from.

The release workflow emits it beside the existing patch step, for **both** the Qt and Tauri research paths.

### Design notes

- **Rules match the category name anchored end to end** (`^Video\ Streaming$`), because by the time aw-webui sees an event, `app` *is* the category name.
- **Names are regex-escaped.** Several contain `&`, `/` or `-` — `Sensitive / Excluded`, `Shopping - Groceries & Food`, `AI Chatbots & Assistants`. An unescaped name is a silently broken rule, which would look exactly like the bug being fixed.
- **Output is sorted and compact**, so the same map always yields a byte-identical preset and the value survives `$GITHUB_ENV` (which terminates at a newline).
- 18 labels: Matthias's 17 study categories plus the `Excluded` residual.

## Verification

5 tests: preset covers exactly the watcher map's categories; every rule matches its own name and neither an unrelated app nor a superstring; metacharacter escaping is asserted explicitly; output is stable across runs; serialisation is newline-free and round-trips.

Deliberately in its own test file so it does not conflict with #1398, which rewrites the patch-script tests.

## Dependencies and ordering

Depends on ActivityWatch/aw-webui#936 plus the aw-webui submodule bump that carries it. **Until then the variable is simply unread and builds are unchanged** — so this is safe to merge in any order.

Related: #1397 (app map), #1398 (keeps the patch script working past aw-watcher-window#137), aw-webui#936 (the consumer).