### PR TITLE
ci(release): export VERSION_NO_V so the aw-server-rust version check sees the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,7 @@ jobs:
           VERSION_WITH_V="${VERSION_WITH_V%-research}"
           VERSION_NO_V="${VERSION_WITH_V#v}"
           echo "VERSION_WITH_V=${VERSION_WITH_V}" >> "$GITHUB_ENV"
+          echo "VERSION_NO_V=${VERSION_NO_V}" >> "$GITHUB_ENV"
           echo "========================================"
           echo "Build Version Information"
           echo "========================================"
@@ -328,6 +329,10 @@ jobs:
           fi
 
           AW_VERSION="${VERSION_NO_V}"  # e.g. "0.14.0b3"
+          if [ -z "$AW_VERSION" ]; then
+            echo "ERROR: VERSION_NO_V is empty — the 'Determine and output version' step must export it to GITHUB_ENV" >&2
+            exit 1
+          fi
           AW_MAJOR_MINOR=$(echo "$AW_VERSION" | cut -d'.' -f1-2)  # "0.14"
           AWS_MAJOR_MINOR=$(echo "$BUNDLED_VERSION" | cut -d'.' -f1-2)  # "0.14"
 
@@ -572,6 +577,7 @@ jobs:
           VERSION_WITH_V="${VERSION_WITH_V%-research}"
           VERSION_NO_V="${VERSION_WITH_V#v}"
           echo "VERSION_WITH_V=${VERSION_WITH_V}" >> "$GITHUB_ENV"
+          echo "VERSION_NO_V=${VERSION_NO_V}" >> "$GITHUB_ENV"
           echo "========================================"
           echo "Build Version Information (Tauri)"
           echo "========================================"
@@ -600,6 +606,10 @@ jobs:
           fi
 
           AW_VERSION="${VERSION_NO_V}"  # e.g. "0.14.0b3"
+          if [ -z "$AW_VERSION" ]; then
+            echo "ERROR: VERSION_NO_V is empty — the 'Determine and output version' step must export it to GITHUB_ENV" >&2
+            exit 1
+          fi
           AW_MAJOR_MINOR=$(echo "$AW_VERSION" | cut -d'.' -f1-2)  # "0.14"
           AWS_MAJOR_MINOR=$(echo "$BUNDLED_VERSION" | cut -d'.' -f1-2)  # "0.14"
 


### PR DESCRIPTION
Fixes #1402.

The `v0.14.0b4` release run failed at *Verify aw-server-rust submodule version matches release tag*:

```
AW release tag:        (major.minor: )
Bundled aw-server:    0.14.0 (major.minor: 0.14)
ERROR: aw-server-rust major.minor (0.14) does not match AW release major.minor ().
```

The submodule is fine. The *Determine and output version* step computes `VERSION_NO_V` but only writes `VERSION_WITH_V` to `$GITHUB_ENV`, so the check (added in #1391) always compared against an empty string — every tagged release has failed this step since.

Changes (both the Qt and Tauri jobs):
- export `VERSION_NO_V` to `$GITHUB_ENV`
- fail with an explicit "VERSION_NO_V is empty" message if it ever regresses, instead of the misleading "submodule is stale" error

Re-tagging `v0.14.0b4` (or tagging b5) after merge should get past this step.

https://claude.ai/code/session_011VKFZeMpLvtZ3e15S1fKUW