### PR TITLE
fix(ci): propagate retried build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -717,6 +717,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command: |
+            set -e
             python3 -m venv venv
             source venv/bin/activate || source venv/Scripts/activate
             poetry install
@@ -946,4 +947,3 @@ jobs:
           prerelease: ${{ !(steps.version.outputs.is_stable == 'true') }}
 
 # Retry CI after transient upload-artifact timeout.
-


### PR DESCRIPTION
## Problem

The Tauri build uses nick-fields/retry with a custom Bash command that did not enable fail-fast behavior. When make build failed, the trailing pip freeze returned zero, so the retry action treated a partial build as successful.

This happened in the macOS Intel job of TimeToBuildBob/activitywatch run 32205310837: aw-tauri failed before the root Makefile restored the local aw-client checkout, pip freeze showed aw-client 0.5.14, and the next step ran checkout tests against that stale installed package.

## Fix

Enable Bash errexit inside the retried Build command. A failed install or build now reaches the retry action immediately, and tests only run after the complete build path succeeds.

I deliberately kept the aw-client tests unchanged: switching them to force source imports would silence this useful packaging-environment canary.

## Verification

- Parsed release.yml as YAML and located the single retried Build command.
- Executed its set -e preamble against a failing command; the shell returned nonzero and did not execute the trailing marker.
- Reproduced the original signature separately: bare pytest with aw-client 0.5.14 installed failed the same two tests, while python -m pytest against the checkout passed.
- Local pre-PR quality gate: 100/100.