### PR TITLE
docs: Add HPR to the comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | Selfspy       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | ulogme        | :x:                | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |Limited functionality|
-| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x: |           |
+| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:             |
 
 ##### Tracking
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | [ulogme]        | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark: |
 | [RescueTime]    | :x:                | :white_check_mark: | Centralized                | :x:                |
 | [WakaTime]      | :x:                | :white_check_mark: | Centralized                | Clients            |
-| [HPR]           | :white_check_mark: | :white_check_mark: | :x:                        |
-:white_check_mark: |
+| [HPR]           | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark: |
 
 [sync]: https://github.com/ActivityWatch/activitywatch/issues/35
 [Selfspy]: https://github.com/selfspy/selfspy
@@ -168,7 +167,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | Selfspy       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | ulogme        | :x:                | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |Limited functionality|
-| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                |
+| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:
 
 ##### Tracking
 
@@ -179,7 +178,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | ulogme        | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                   |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                   |
 | WakaTime      | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | Only for text editors |
-| HPR           | :white_check_mark: | :white_check_mark: | :x: (Title parsing)| :x: (Title parsing)|
+| HPR           | :white_check_mark: | :white_check_mark: | :x: (Title parsing)| :x: (Title parsing)| :white_check_mark: |
 
 For a complete list of the things ActivityWatch can track, [see the page on *watchers* in the documentation](https://docs.activitywatch.net/en/latest/watchers.html).
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | Selfspy       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | ulogme        | :x:                | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |Limited functionality|
-| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x:
+| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                | :x: |           |
 
 ##### Tracking
 
@@ -178,7 +178,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | ulogme        | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                   |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                   |
 | WakaTime      | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | Only for text editors |
-| HPR           | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :white_check_mark: |
+| HPR           | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :white_check_mark:    |
 
 For a complete list of the things ActivityWatch can track, [see the page on *watchers* in the documentation](https://docs.activitywatch.net/en/latest/watchers.html).
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | ulogme        | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                   |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                   |
 | WakaTime      | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | Only for text editors |
-| HPR           | :white_check_mark: | :white_check_mark: | :x: (Title parsing)| :x: (Title parsing)| :white_check_mark: |
+| HPR           | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :white_check_mark: |
 
 For a complete list of the things ActivityWatch can track, [see the page on *watchers* in the documentation](https://docs.activitywatch.net/en/latest/watchers.html).
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,15 @@ We have a plan to address all of these and we're well on our way. See the table 
 | [ulogme]        | :white_check_mark: | :white_check_mark: | :x:                        | :white_check_mark: |
 | [RescueTime]    | :x:                | :white_check_mark: | Centralized                | :x:                |
 | [WakaTime]      | :x:                | :white_check_mark: | Centralized                | Clients            |
+| [HPR]           | :white_check_mark: | :white_check_mark: | :x:                        |
+:white_check_mark: |
 
 [sync]: https://github.com/ActivityWatch/activitywatch/issues/35
 [Selfspy]: https://github.com/selfspy/selfspy
 [ulogme]: https://github.com/karpathy/ulogme
 [RescueTime]: https://www.rescuetime.com/
 [WakaTime]: https://wakatime.com/
+[HPR]: https://github.com/plexescor/HPR
 
 ##### Platforms
 <!-- TODO: Replace Platform names with icons  -->
@@ -165,6 +168,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | Selfspy       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | ulogme        | :x:                | :white_check_mark: | :white_check_mark: | :x:                |:x:                  |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |Limited functionality|
+| HPR           | :white_check_mark: | :x:                | :white_check_mark: | :x:                |
 
 ##### Tracking
 
@@ -175,6 +179,7 @@ We have a plan to address all of these and we're well on our way. See the table 
 | ulogme        | :white_check_mark: | :white_check_mark: | :x:                | :x:                | :x:                   |
 | RescueTime    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                | :x:                   |
 | WakaTime      | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | Only for text editors |
+| HPR           | :white_check_mark: | :white_check_mark: | :x: (Title parsing)| :x: (Title parsing)|
 
 For a complete list of the things ActivityWatch can track, [see the page on *watchers* in the documentation](https://docs.activitywatch.net/en/latest/watchers.html).
 


### PR DESCRIPTION
Summary: [HPR](https://github.com/plexescor/HPR) has been added to the comparison table in the README