### PR TITLE
macOS: add Apple Events entitlement for native browser URL capture

### DIFF
--- a/aw.spec
+++ b/aw.spec
@@ -36,7 +36,7 @@ def build_analysis(name, location, binaries=[], datas=[], hiddenimports=[]):
     )
 
 
-def build_collect(analysis, name, console=True):
+def build_collect(analysis, name, console=True, entitlements=None):
     """Used to build the COLLECT statements for each module"""
     pyz = PYZ(analysis.pure, analysis.zipped_data)
     exe = EXE(
@@ -49,7 +49,7 @@ def build_collect(analysis, name, console=True):
         upx=True,
         console=console,
         contents_directory=".",
-        entitlements_file=entitlements_file,
+        entitlements_file=entitlements or entitlements_file,
         codesign_identity=codesign_identity,
     )
     return COLLECT(
@@ -74,6 +74,7 @@ print("bundling activitywatch version " + current_release)
 
 # Get entitlements and codesign identity
 entitlements_file = Path(".") / "scripts" / "package" / "entitlements.plist"
+app_entitlements_file = Path(".") / "scripts" / "package" / "app-entitlements.plist"
 codesign_identity = os.environ.get("APPLE_PERSONALID", "").strip()
 if not codesign_identity:
     print("Environment variable APPLE_PERSONALID not set. Releases won't be signed.")
@@ -92,6 +93,8 @@ awi_location = Path("aw-watcher-input")
 aw_notify_location = Path("aw-notify")
 
 if platform.system() == "Darwin":
+    from PyInstaller.utils import osx as osxutils
+
     icon = aw_qt_location / "media/logo/logo.icns"
 else:
     icon = aw_qt_location / "media/logo/logo.ico"
@@ -208,6 +211,7 @@ awq_coll = build_collect(
     aw_qt_a,
     "aw-qt",
     console=False if platform.system() == "Windows" else True,
+    entitlements=app_entitlements_file,
 )
 
 # aw-watcher-input
@@ -244,3 +248,8 @@ if platform.system() == "Darwin":
             # "CFBundleShortVersionString": current_release.lstrip('v'),
         },
     )
+
+    # BUNDLE inherits signing settings from the last COLLECT and deep-signs the
+    # assembled bundle with them. Re-sign the application layer so its responsible
+    # executable retains app-only capabilities without propagating them to helpers.
+    osxutils.sign_binary(app.name, codesign_identity, app_entitlements_file)

--- a/scripts/package/app-entitlements.plist
+++ b/scripts/package/app-entitlements.plist
@@ -2,11 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Shared by nested binaries; app-only capabilities belong in app-entitlements.plist. -->
 	<!-- These are required for binaries built by PyInstaller -->
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<!-- The responsible application needs this to prompt for browser Apple Events access. -->
+	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 </dict>
 </plist>

--- a/scripts/package/build_app_tauri.sh
+++ b/scripts/package/build_app_tauri.sh
@@ -144,6 +144,7 @@ if [ -n "$APPLE_PERSONALID" ]; then
     # then .framework bundles, then the top-level .app last.
     # --timestamp is required for notarization (Apple rejects submissions without it).
     ENTITLEMENTS="scripts/package/entitlements.plist"
+    APP_ENTITLEMENTS="scripts/package/app-entitlements.plist"
 
     sign_binary() {
         echo "  Signing: $1"
@@ -263,7 +264,10 @@ if [ -n "$APPLE_PERSONALID" ]; then
 
     # Step 3: Sign the top-level .app bundle last.
     echo "  Signing top-level .app bundle..."
-    sign_binary "dist/${APP_NAME}.app"
+    codesign --force --options runtime --timestamp \
+        --entitlements "$APP_ENTITLEMENTS" \
+        --sign "$APPLE_PERSONALID" \
+        "dist/${APP_NAME}.app"
 
     echo "App signing complete."
 else


### PR DESCRIPTION
## Summary

ActivityWatch's native macOS watcher already retrieves Chrome and Safari URLs through Apple Events/ScriptingBridge. Distributed macOS builds use Hardened Runtime, but the responsible outer application is not signed with `com.apple.security.automation.apple-events`, so TCC refuses to present the Automation permission prompt.

The decisive TCC diagnostic is:

```text
Prompting policy for hardened runtime; service: kTCCServiceAppleEvents requires
entitlement com.apple.security.automation.apple-events but it is missing
```

Controlled before/after testing showed the existing watcher working once the entitlement was added to the responsible application:

```text
Before: Chrome event url = ""
After:  Chrome event url = "https://example.com/..."
```

## Change

- Add an app-level entitlement plist containing the existing PyInstaller runtime entitlements plus Apple Events Automation.
- Apply it to the responsible outer application in both Qt and Tauri packaging paths.
- Keep nested watchers/helpers on the narrower shared entitlement set.
- Re-sign the completed Qt bundle at the application layer because PyInstaller's final `BUNDLE` signing pass otherwise replaces the earlier `aw-qt` signature settings.

<details>
<summary>Artifact validation</summary>

- Built the Qt artifact through `pyinstaller --clean --noconfirm aw.spec`.
- Built the Tauri artifact through the repository's `TAURI_BUILD=true` build/package flow.
- Verified the Automation entitlement on `aw-qt` and `aw-tauri`, and its absence from nested `aw-watcher-window` and Swift helper executables.
- Scanned both bundle layouts for unintended entitlement propagation.
- `codesign --verify --deep --strict` passed for both artifacts.
- Built and verified a DMG locally.

Developer ID notarization was not reproduced without production Apple credentials; upstream release CI remains the authoritative validation for that layer.

</details>
