### PR TITLE
build: sync server submodule from Tauri lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 # We recommend creating and activating a Python virtualenv before building.
 # Instructions on how to do this can be found in the guide linked above.
-.PHONY: build install test clean clean_all
+.PHONY: build install test clean clean_all update-submodules sync-tauri-server
 
 SHELL := /usr/bin/env bash
 
@@ -103,6 +103,17 @@ update:
 	git pull
 	git submodule update --init --recursive
 	make build
+
+# Move direct submodules to their latest upstream commits. aw-tauri's lockfile
+# is authoritative for the server revision, so align the top-level server
+# submodule with it after updating everything else.
+update-submodules:
+	git submodule update --init --remote
+	git submodule foreach 'git submodule update --init --recursive'
+	$(MAKE) sync-tauri-server
+
+sync-tauri-server:
+	python3 scripts/check_tauri_server.py --sync
 
 
 lint:

--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 
 FIELD_RE = re.compile(r'^\s*([a-zA-Z0-9_-]+)\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
@@ -64,24 +64,25 @@ def read_locked_server(cargo_lock: Path) -> Tuple[str, str]:
 
 
 def validation_errors(
-    release_version: str,
+    release_version: Optional[str],
     submodule_version: str,
     submodule_revision: str,
     tauri_version: str,
     tauri_revision: str,
 ) -> List[str]:
-    release_line = major_minor(release_version)
     errors = []
-    if major_minor(submodule_version) != release_line:
-        errors.append(
-            f"aw-server-rust submodule version {submodule_version} does not match "
-            f"release line {release_line}"
-        )
-    if major_minor(tauri_version) != release_line:
-        errors.append(
-            f"Tauri locks aw-server {tauri_version}, which does not match release line "
-            f"{release_line}"
-        )
+    if release_version is not None:
+        release_line = major_minor(release_version)
+        if major_minor(submodule_version) != release_line:
+            errors.append(
+                f"aw-server-rust submodule version {submodule_version} does not match "
+                f"release line {release_line}"
+            )
+        if major_minor(tauri_version) != release_line:
+            errors.append(
+                f"Tauri locks aw-server {tauri_version}, which does not match release line "
+                f"{release_line}"
+            )
     if tauri_revision != submodule_revision:
         errors.append(
             f"Tauri locks aw-server-rust {tauri_revision[:12]}, but the release "
@@ -90,26 +91,88 @@ def validation_errors(
     return errors
 
 
+def sync_submodule(server_root: Path, revision: str) -> bool:
+    """Check out the Tauri-locked revision in the top-level server submodule."""
+    current_revision = subprocess.check_output(
+        ["git", "-C", str(server_root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    if current_revision == revision:
+        return False
+
+    dirty = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(server_root),
+            "status",
+            "--porcelain",
+            "--untracked-files=no",
+            "--ignore-submodules=all",
+        ],
+        text=True,
+    ).strip()
+    if dirty:
+        raise ValueError(
+            f"refusing to replace dirty aw-server-rust checkout at {server_root}"
+        )
+
+    try:
+        subprocess.run(
+            ["git", "-C", str(server_root), "cat-file", "-e", f"{revision}^{{commit}}"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        subprocess.run(
+            ["git", "-C", str(server_root), "fetch", "origin", revision], check=True
+        )
+
+    subprocess.run(
+        ["git", "-C", str(server_root), "checkout", "--detach", revision], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(server_root), "submodule", "update", "--init", "--recursive"],
+        check=True,
+    )
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "release_version", help="ActivityWatch version without the leading v"
+        "release_version",
+        nargs="?",
+        help="ActivityWatch version without the leading v (required unless --sync)",
+    )
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="make the top-level aw-server-rust submodule follow Tauri's Cargo.lock",
     )
     parser.add_argument(
         "--repo-root", type=Path, default=Path(__file__).resolve().parents[1]
     )
     args = parser.parse_args()
+    if args.release_version is None and not args.sync:
+        parser.error("release_version is required unless --sync is used")
 
     root = args.repo_root.resolve()
     server_root = root / "aw-server-rust"
     try:
+        tauri_version, tauri_revision = read_locked_server(
+            root / "aw-tauri/src-tauri/Cargo.lock"
+        )
+        if args.sync:
+            changed = sync_submodule(server_root, tauri_revision)
+            if changed:
+                print(f"Synced aw-server-rust to Tauri lock {tauri_revision[:12]}")
+            else:
+                print(f"aw-server-rust already matches Tauri lock {tauri_revision[:12]}")
         submodule_version = read_package_version(server_root / "aw-server/Cargo.toml")
         submodule_revision = subprocess.check_output(
             ["git", "-C", str(server_root), "rev-parse", "HEAD"], text=True
         ).strip()
-        tauri_version, tauri_revision = read_locked_server(
-            root / "aw-tauri/src-tauri/Cargo.lock"
-        )
         errors = validation_errors(
             args.release_version,
             submodule_version,
@@ -124,7 +187,8 @@ def main() -> int:
         )
         return 1
 
-    print(f"ActivityWatch release: {args.release_version}")
+    if args.release_version is not None:
+        print(f"ActivityWatch release: {args.release_version}")
     print(f"aw-server-rust:       {submodule_version} @ {submodule_revision[:12]}")
     print(f"Tauri Cargo.lock:     {tauri_version} @ {tauri_revision[:12]}")
     if errors:
@@ -132,8 +196,8 @@ def main() -> int:
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         print(
-            "\nUpdate both the aw-server-rust submodule and aw-tauri's Cargo.lock "
-            "to the same revision before tagging.",
+            "\nRun `make sync-tauri-server` to make the top-level submodule "
+            "follow aw-tauri's Cargo.lock.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -93,6 +93,17 @@ def validation_errors(
 
 def sync_submodule(server_root: Path, revision: str) -> bool:
     """Check out the Tauri-locked revision in the top-level server submodule."""
+    git_root = Path(
+        subprocess.check_output(
+            ["git", "-C", str(server_root), "rev-parse", "--show-toplevel"],
+            text=True,
+        ).strip()
+    ).resolve()
+    if git_root != server_root.resolve():
+        raise ValueError(
+            f"aw-server-rust is not initialized as a Git submodule at {server_root}"
+        )
+
     current_revision = subprocess.check_output(
         ["git", "-C", str(server_root), "rev-parse", "HEAD"], text=True
     ).strip()
@@ -164,6 +175,18 @@ def main() -> int:
             root / "aw-tauri/src-tauri/Cargo.lock"
         )
         if args.sync:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(root),
+                    "submodule",
+                    "update",
+                    "--init",
+                    "aw-server-rust",
+                ],
+                check=True,
+            )
             changed = sync_submodule(server_root, tauri_revision)
             if changed:
                 print(f"Synced aw-server-rust to Tauri lock {tauri_revision[:12]}")
@@ -195,11 +218,21 @@ def main() -> int:
         print("\nERROR: inconsistent aw-server build inputs:", file=sys.stderr)
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
-        print(
-            "\nRun `make sync-tauri-server` to make the top-level submodule "
-            "follow aw-tauri's Cargo.lock.",
-            file=sys.stderr,
-        )
+        if (
+            args.release_version is not None
+            and major_minor(tauri_version) != major_minor(args.release_version)
+        ):
+            print(
+                "\nUpdate aw-tauri's Cargo.lock to the intended server release line, "
+                "then run `make sync-tauri-server`.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "\nRun `make sync-tauri-server` to make the top-level submodule "
+                "follow aw-tauri's Cargo.lock.",
+                file=sys.stderr,
+            )
         return 1
 
     print("OK: Qt and Tauri will bundle the same aw-server-rust revision")

--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -171,9 +171,6 @@ def main() -> int:
     root = args.repo_root.resolve()
     server_root = root / "aw-server-rust"
     try:
-        tauri_version, tauri_revision = read_locked_server(
-            root / "aw-tauri/src-tauri/Cargo.lock"
-        )
         if args.sync:
             subprocess.run(
                 [
@@ -183,10 +180,15 @@ def main() -> int:
                     "submodule",
                     "update",
                     "--init",
+                    "aw-tauri",
                     "aw-server-rust",
                 ],
                 check=True,
             )
+        tauri_version, tauri_revision = read_locked_server(
+            root / "aw-tauri/src-tauri/Cargo.lock"
+        )
+        if args.sync:
             changed = sync_submodule(server_root, tauri_revision)
             if changed:
                 print(f"Synced aw-server-rust to Tauri lock {tauri_revision[:12]}")

--- a/scripts/tests/test_check_tauri_server.py
+++ b/scripts/tests/test_check_tauri_server.py
@@ -1,4 +1,5 @@
 import importlib.util
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ major_minor = checker.major_minor
 read_locked_server = checker.read_locked_server
 read_package_version = checker.read_package_version
 validation_errors = checker.validation_errors
+sync_submodule = checker.sync_submodule
 
 
 REVISION = "a" * 40
@@ -67,3 +69,54 @@ def test_rejects_different_revision_even_on_same_release_line():
 def test_rejects_invalid_version():
     with pytest.raises(ValueError, match="invalid version"):
         major_minor("dev")
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def make_git_repo(path: Path) -> tuple[str, str]:
+    path.mkdir()
+    subprocess.run(["git", "-C", str(path), "init"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"], check=True
+    )
+    tracked = path / "tracked.txt"
+    tracked.write_text("first\n")
+    subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "first"],
+        check=True,
+        capture_output=True,
+    )
+    first = git(path, "rev-parse", "HEAD")
+    tracked.write_text("second\n")
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-am", "second"],
+        check=True,
+        capture_output=True,
+    )
+    return first, git(path, "rev-parse", "HEAD")
+
+
+def test_sync_submodule_checks_out_locked_revision(tmp_path: Path):
+    repo = tmp_path / "aw-server-rust"
+    first, second = make_git_repo(repo)
+    assert git(repo, "rev-parse", "HEAD") == second
+
+    assert sync_submodule(repo, first)
+    assert git(repo, "rev-parse", "HEAD") == first
+    assert not sync_submodule(repo, first)
+
+
+def test_sync_submodule_refuses_dirty_checkout(tmp_path: Path):
+    repo = tmp_path / "aw-server-rust"
+    first, _ = make_git_repo(repo)
+    (repo / "tracked.txt").write_text("dirty\n")
+
+    with pytest.raises(ValueError, match="refusing to replace dirty"):
+        sync_submodule(repo, first)

--- a/scripts/tests/test_check_tauri_server.py
+++ b/scripts/tests/test_check_tauri_server.py
@@ -120,3 +120,13 @@ def test_sync_submodule_refuses_dirty_checkout(tmp_path: Path):
 
     with pytest.raises(ValueError, match="refusing to replace dirty"):
         sync_submodule(repo, first)
+
+
+def test_sync_submodule_rejects_uninitialized_nested_directory(tmp_path: Path):
+    parent = tmp_path / "activitywatch"
+    _, _ = make_git_repo(parent)
+    server = parent / "aw-server-rust"
+    server.mkdir()
+
+    with pytest.raises(ValueError, match="not initialized as a Git submodule"):
+        sync_submodule(server, REVISION)


### PR DESCRIPTION
## Summary
- make `aw-tauri/src-tauri/Cargo.lock` authoritative for the bundled `aw-server-rust` revision
- add `make sync-tauri-server` to initialize and align the top-level server submodule with that lock
- add `make update-submodules` so normal direct-submodule updates finish by applying that alignment
- refuse to overwrite a dirty top-level server checkout and fetch the locked commit only when needed

## Validation
- `python3 -m pytest scripts/tests -q` (35 passed)
- Python 3.9 compile check
- verified standalone sync initializes a deinitialized `aw-server-rust` submodule
- advanced `aw-server-rust` to current upstream and verified `make sync-tauri-server` restored the locked revision
- ran `make update-submodules` end-to-end and verified the resulting server gitlink matched the updated Tauri lock
- `git diff --check`