### PR TITLE
fix: preserve updated submodules during sync

### DIFF
--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -126,9 +126,40 @@ def initialize_submodule(root: Path, name: str) -> bool:
             ).strip()
         ).resolve()
         if actual_git_dir != expected_git_dir:
-            raise ValueError(
-                f"refusing unrelated Git checkout at configured submodule path {path}"
-            )
+            # Git also supports an old-form submodule with its Git directory
+            # embedded at <path>/.git. Accept that only when its origin is the
+            # URL configured for this exact submodule; other repositories at
+            # the configured path must never be rewritten by synchronization.
+            try:
+                expected_url = subprocess.check_output(
+                    [
+                        "git",
+                        "-C",
+                        str(root),
+                        "config",
+                        "-f",
+                        ".gitmodules",
+                        "--get",
+                        f"submodule.{name}.url",
+                    ],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+                actual_url = subprocess.check_output(
+                    ["git", "-C", str(path), "remote", "get-url", "origin"],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+            except subprocess.CalledProcessError:
+                expected_url = actual_url = ""
+            if (
+                not (path / ".git").is_dir()
+                or not expected_url
+                or actual_url != expected_url
+            ):
+                raise ValueError(
+                    f"refusing unrelated Git checkout at configured submodule path {path}"
+                )
         return False
     subprocess.run(
         ["git", "-C", str(root), "submodule", "update", "--init", name], check=True

--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -91,15 +91,34 @@ def validation_errors(
     return errors
 
 
+def is_git_checkout(path: Path) -> bool:
+    """Return whether path is the root of an initialized Git checkout."""
+    try:
+        git_root = Path(
+            subprocess.check_output(
+                ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        ).resolve()
+    except subprocess.CalledProcessError:
+        return False
+    return git_root == path.resolve()
+
+
+def initialize_submodule(root: Path, name: str) -> bool:
+    """Initialize a missing submodule without resetting an updated checkout."""
+    if is_git_checkout(root / name):
+        return False
+    subprocess.run(
+        ["git", "-C", str(root), "submodule", "update", "--init", name], check=True
+    )
+    return True
+
+
 def sync_submodule(server_root: Path, revision: str) -> bool:
     """Check out the Tauri-locked revision in the top-level server submodule."""
-    git_root = Path(
-        subprocess.check_output(
-            ["git", "-C", str(server_root), "rev-parse", "--show-toplevel"],
-            text=True,
-        ).strip()
-    ).resolve()
-    if git_root != server_root.resolve():
+    if not is_git_checkout(server_root):
         raise ValueError(
             f"aw-server-rust is not initialized as a Git submodule at {server_root}"
         )
@@ -172,19 +191,8 @@ def main() -> int:
     server_root = root / "aw-server-rust"
     try:
         if args.sync:
-            subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(root),
-                    "submodule",
-                    "update",
-                    "--init",
-                    "aw-tauri",
-                    "aw-server-rust",
-                ],
-                check=True,
-            )
+            initialize_submodule(root, "aw-tauri")
+            initialize_submodule(root, "aw-server-rust")
         tauri_version, tauri_revision = read_locked_server(
             root / "aw-tauri/src-tauri/Cargo.lock"
         )

--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -108,7 +108,27 @@ def is_git_checkout(path: Path) -> bool:
 
 def initialize_submodule(root: Path, name: str) -> bool:
     """Initialize a missing submodule without resetting an updated checkout."""
-    if is_git_checkout(root / name):
+    path = root / name
+    if is_git_checkout(path):
+        expected_git_dir = Path(
+            subprocess.check_output(
+                ["git", "-C", str(root), "rev-parse", "--git-path", f"modules/{name}"],
+                text=True,
+            ).strip()
+        )
+        if not expected_git_dir.is_absolute():
+            expected_git_dir = root / expected_git_dir
+        expected_git_dir = expected_git_dir.resolve()
+        actual_git_dir = Path(
+            subprocess.check_output(
+                ["git", "-C", str(path), "rev-parse", "--absolute-git-dir"],
+                text=True,
+            ).strip()
+        ).resolve()
+        if actual_git_dir != expected_git_dir:
+            raise ValueError(
+                f"refusing unrelated Git checkout at configured submodule path {path}"
+            )
         return False
     subprocess.run(
         ["git", "-C", str(root), "submodule", "update", "--init", name], check=True
@@ -122,12 +142,6 @@ def sync_submodule(server_root: Path, revision: str) -> bool:
         raise ValueError(
             f"aw-server-rust is not initialized as a Git submodule at {server_root}"
         )
-
-    current_revision = subprocess.check_output(
-        ["git", "-C", str(server_root), "rev-parse", "HEAD"], text=True
-    ).strip()
-    if current_revision == revision:
-        return False
 
     dirty = subprocess.check_output(
         [
@@ -145,6 +159,12 @@ def sync_submodule(server_root: Path, revision: str) -> bool:
         raise ValueError(
             f"refusing to replace dirty aw-server-rust checkout at {server_root}"
         )
+
+    current_revision = subprocess.check_output(
+        ["git", "-C", str(server_root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    if current_revision == revision:
+        return False
 
     try:
         subprocess.run(

--- a/scripts/check_tauri_server.py
+++ b/scripts/check_tauri_server.py
@@ -126,40 +126,16 @@ def initialize_submodule(root: Path, name: str) -> bool:
             ).strip()
         ).resolve()
         if actual_git_dir != expected_git_dir:
-            # Git also supports an old-form submodule with its Git directory
-            # embedded at <path>/.git. Accept that only when its origin is the
-            # URL configured for this exact submodule; other repositories at
-            # the configured path must never be rewritten by synchronization.
-            try:
-                expected_url = subprocess.check_output(
-                    [
-                        "git",
-                        "-C",
-                        str(root),
-                        "config",
-                        "-f",
-                        ".gitmodules",
-                        "--get",
-                        f"submodule.{name}.url",
-                    ],
-                    text=True,
-                    stderr=subprocess.DEVNULL,
-                ).strip()
-                actual_url = subprocess.check_output(
-                    ["git", "-C", str(path), "remote", "get-url", "origin"],
-                    text=True,
-                    stderr=subprocess.DEVNULL,
-                ).strip()
-            except subprocess.CalledProcessError:
-                expected_url = actual_url = ""
-            if (
-                not (path / ".git").is_dir()
-                or not expected_url
-                or actual_url != expected_url
-            ):
-                raise ValueError(
-                    f"refusing unrelated Git checkout at configured submodule path {path}"
+            hint = ""
+            if (path / ".git").is_dir():
+                hint = (
+                    f"; if this is an old-form submodule, migrate it first with "
+                    f"'git submodule absorbgitdirs {name}'"
                 )
+            raise ValueError(
+                f"refusing unmanaged Git checkout at configured submodule path {path}"
+                f"{hint}"
+            )
         return False
     subprocess.run(
         ["git", "-C", str(root), "submodule", "update", "--init", name], check=True

--- a/scripts/tests/test_check_tauri_server.py
+++ b/scripts/tests/test_check_tauri_server.py
@@ -152,3 +152,21 @@ def test_initialize_submodule_rejects_unrelated_checkout(tmp_path: Path):
 
     with pytest.raises(ValueError, match="refusing unrelated Git checkout"):
         initialize_submodule(parent, "aw-server-rust")
+
+
+def test_initialize_submodule_accepts_old_form_checkout(tmp_path: Path):
+    parent = tmp_path / "activitywatch"
+    _, _ = make_git_repo(parent)
+    server = parent / "aw-server-rust"
+    _, _ = make_git_repo(server)
+    url = "https://github.com/ActivityWatch/aw-server-rust.git"
+    subprocess.run(
+        ["git", "-C", str(server), "remote", "add", "origin", url], check=True
+    )
+    (parent / ".gitmodules").write_text(
+        f'[submodule "aw-server-rust"]\n'
+        "\tpath = aw-server-rust\n"
+        f"\turl = {url}\n"
+    )
+
+    assert not initialize_submodule(parent, "aw-server-rust")

--- a/scripts/tests/test_check_tauri_server.py
+++ b/scripts/tests/test_check_tauri_server.py
@@ -16,6 +16,7 @@ read_locked_server = checker.read_locked_server
 read_package_version = checker.read_package_version
 validation_errors = checker.validation_errors
 is_git_checkout = checker.is_git_checkout
+initialize_submodule = checker.initialize_submodule
 sync_submodule = checker.sync_submodule
 
 
@@ -116,11 +117,11 @@ def test_sync_submodule_checks_out_locked_revision(tmp_path: Path):
 
 def test_sync_submodule_refuses_dirty_checkout(tmp_path: Path):
     repo = tmp_path / "aw-server-rust"
-    first, _ = make_git_repo(repo)
+    _, current = make_git_repo(repo)
     (repo / "tracked.txt").write_text("dirty\n")
 
     with pytest.raises(ValueError, match="refusing to replace dirty"):
-        sync_submodule(repo, first)
+        sync_submodule(repo, current)
 
 
 def test_sync_submodule_rejects_uninitialized_nested_directory(tmp_path: Path):
@@ -141,3 +142,13 @@ def test_is_git_checkout_requires_the_exact_repository_root(tmp_path: Path):
 
     assert is_git_checkout(repo)
     assert not is_git_checkout(nested)
+
+
+def test_initialize_submodule_rejects_unrelated_checkout(tmp_path: Path):
+    parent = tmp_path / "activitywatch"
+    _, _ = make_git_repo(parent)
+    unrelated = parent / "aw-server-rust"
+    _, _ = make_git_repo(unrelated)
+
+    with pytest.raises(ValueError, match="refusing unrelated Git checkout"):
+        initialize_submodule(parent, "aw-server-rust")

--- a/scripts/tests/test_check_tauri_server.py
+++ b/scripts/tests/test_check_tauri_server.py
@@ -15,6 +15,7 @@ major_minor = checker.major_minor
 read_locked_server = checker.read_locked_server
 read_package_version = checker.read_package_version
 validation_errors = checker.validation_errors
+is_git_checkout = checker.is_git_checkout
 sync_submodule = checker.sync_submodule
 
 
@@ -130,3 +131,13 @@ def test_sync_submodule_rejects_uninitialized_nested_directory(tmp_path: Path):
 
     with pytest.raises(ValueError, match="not initialized as a Git submodule"):
         sync_submodule(server, REVISION)
+
+
+def test_is_git_checkout_requires_the_exact_repository_root(tmp_path: Path):
+    repo = tmp_path / "activitywatch"
+    _, _ = make_git_repo(repo)
+    nested = repo / "aw-server-rust"
+    nested.mkdir()
+
+    assert is_git_checkout(repo)
+    assert not is_git_checkout(nested)

--- a/scripts/tests/test_check_tauri_server.py
+++ b/scripts/tests/test_check_tauri_server.py
@@ -150,11 +150,13 @@ def test_initialize_submodule_rejects_unrelated_checkout(tmp_path: Path):
     unrelated = parent / "aw-server-rust"
     _, _ = make_git_repo(unrelated)
 
-    with pytest.raises(ValueError, match="refusing unrelated Git checkout"):
+    with pytest.raises(ValueError, match="refusing unmanaged Git checkout"):
         initialize_submodule(parent, "aw-server-rust")
 
 
-def test_initialize_submodule_accepts_old_form_checkout(tmp_path: Path):
+def test_initialize_submodule_rejects_old_form_checkout_with_migration_hint(
+    tmp_path: Path,
+):
     parent = tmp_path / "activitywatch"
     _, _ = make_git_repo(parent)
     server = parent / "aw-server-rust"
@@ -169,4 +171,5 @@ def test_initialize_submodule_accepts_old_form_checkout(tmp_path: Path):
         f"\turl = {url}\n"
     )
 
-    assert not initialize_submodule(parent, "aw-server-rust")
+    with pytest.raises(ValueError, match="git submodule absorbgitdirs aw-server-rust"):
+        initialize_submodule(parent, "aw-server-rust")


### PR DESCRIPTION
## Summary
- initialize `aw-tauri` and `aw-server-rust` only when their checkouts are missing
- preserve an `aw-tauri` revision just advanced by `make update-submodules` before reading its lock
- retain protection against Git walking up from an empty submodule directory into the superproject

## Validation
- `python3 -m pytest scripts/tests -q` (36 passed)
- Python 3.9 compile check
- advanced `aw-tauri`, ran `make sync-tauri-server`, and verified its revision was preserved while `aw-server-rust` moved to the new locked SHA
- `git diff --check`

This fixes a follow-up interaction found while applying the newly merged synchronization workflow from #1414.