### PR TITLE
feat(release): enable start-at-login by default in research Qt builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,7 +418,11 @@ jobs:
 
       - name: Patch research edition defaults
         if: env.AW_RESEARCH_EDITION == 'true'
-        run: python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
+        run: |
+          python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
+          # Participants' machines must resume tracking after reboots without
+          # setup steps: enable start-at-login on first launch (aw-qt#131).
+          python3 scripts/patch_research_edition_awqt.py aw-qt/aw_qt/config.py
 
       # Watchers store buckets as `{client}_{hostname}`. That hostname is a
       # participant identifier on named machines, and /api/0/export copies it
@@ -699,7 +703,11 @@ jobs:
 
       - name: Patch research edition defaults
         if: env.AW_RESEARCH_EDITION == 'true'
-        run: python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
+        run: |
+          python3 scripts/patch_research_edition_config.py aw-watcher-window/aw_watcher_window/config.py
+          # Participants' machines must resume tracking after reboots without
+          # setup steps: enable start-at-login on first launch (aw-qt#131).
+          python3 scripts/patch_research_edition_awqt.py aw-qt/aw_qt/config.py
 
       - name: Emit research edition category preset for the web UI
         if: env.AW_RESEARCH_EDITION == 'true'

--- a/scripts/package/getversion.sh
+++ b/scripts/package/getversion.sh
@@ -63,7 +63,11 @@ get_version_internal() {
         _version="$(git describe --tags --abbrev=0 --exact-match 2>/dev/null || true)"
         if [[ -z "$_version" ]]; then
             local _latest_tag
-            _latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")"
+            # Exclude research-edition tags so dev versions off master don't
+            # inherit a "-research" base (e.g. v0.14.0b4-research.dev-abc1234).
+            # Exact-match above intentionally keeps them: building *on* a
+            # research tag must report the research version.
+            _latest_tag="$(git describe --tags --abbrev=0 --exclude '*-research' 2>/dev/null || echo "v0.0.0")"
             local _commit_hash
             _commit_hash="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
             _version="${_latest_tag}.dev-${_commit_hash}"

--- a/scripts/patch_research_edition_awqt.py
+++ b/scripts/patch_research_edition_awqt.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Patch aw-qt's default config for Research Edition builds.
+
+Flips `autostart_on_first_run` from false to true in aw_qt/config.py's
+default_config, so participant machines register start-at-login on first
+launch (aw-qt#131) without any setup steps. The user can still disable it
+from the tray afterwards; aw-qt never re-enables once its marker is written.
+
+Run as part of the CI build for research edition:
+    python3 scripts/patch_research_edition_awqt.py <path/to/aw_qt/config.py>
+
+Fails closed if the key is absent, which means the aw-qt submodule pin
+predates aw-qt#131 — bump the pin rather than shipping a research build
+that silently loses reboot-survival.
+"""
+import pathlib
+import sys
+
+OLD = "autostart_on_first_run = false"
+NEW = "autostart_on_first_run = true"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <path/to/aw_qt/config.py>", file=sys.stderr)
+        return 2
+
+    path = pathlib.Path(sys.argv[1])
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        print(f"ERROR: {path} not found - is the aw-qt submodule checked out?", file=sys.stderr)
+        return 1
+
+    # Only patch the first occurrence: the [aw-qt] section default. The
+    # [aw-qt-testing] section keeps autostart off.
+    if OLD not in text:
+        print(
+            f"ERROR: {OLD!r} not found in {path} - aw-qt submodule pin "
+            "predates aw-qt#131, refusing to build research edition without "
+            "first-run autostart",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(text.replace(OLD, NEW, 1))
+    print(f"Patched {path}: {OLD} -> {NEW} (first occurrence)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Study-readiness follow-ups for the Research Edition (Qt bundle is the study deliverable; participants are Windows/macOS):

- **New `scripts/patch_research_edition_awqt.py`**: research builds flip aw-qt's new `autostart_on_first_run` default (aw-qt#131, merged) to `true`, so participant machines register start-at-login on first launch with zero setup steps. The user's later tray choice is always respected (marker file; disable is never overridden). Fails closed if the aw-qt pin predates the option — a research build can't silently lose reboot-survival.
- **Wired into both Qt build jobs** (`build-qt` and `build-qt-manylinux-2-28`); `build-tauri` untouched since it doesn't bundle aw-qt.
- **Bumps the aw-qt submodule** to include aw-qt#131 (atomically with the fail-closed step, so research builds keep working).
- **`getversion.sh`**: exclude `*-research` tags from the dev-version fallback — master dev builds currently report `v0.14.0b4-research.dev-<sha>` because `git describe` picks the research tag as nearest. Exact-match is deliberately untouched: building *on* a research tag still reports the research version.

Verified locally: patch script success/fail-closed/missing-file paths, getversion output on master (`v0.14.0b4.dev-0a9d836`), workflow YAML parses, aw-qt test suite green on the bumped pin (103 passed).