### PR TITLE
fix(package): resolve edition-suffixed Inno Setup output name

### DIFF
--- a/scripts/package/package-all.sh
+++ b/scripts/package/package-all.sh
@@ -107,7 +107,16 @@ function build_setup() {
     else
         env AW_VERSION=$version_no_prefix "$innosetupdir/iscc.exe" scripts/package/activitywatch-setup.iss
     fi
-    mv dist/activitywatch-setup.exe dist/$filename
+    # The Research Edition patcher rewrites OutputBaseFilename in the .iss
+    # (activitywatch-research[-tauri]-setup), so resolve the produced file
+    # instead of hardcoding the standard name. dist/ is fresh at this point,
+    # so exactly one setup exe must exist.
+    setup_src=(dist/activitywatch*-setup.exe)
+    if [ ${#setup_src[@]} -ne 1 ] || [ ! -f "${setup_src[0]}" ]; then
+        echo "ERROR: expected exactly one dist/activitywatch*-setup.exe, got: ${setup_src[*]}"
+        exit 1
+    fi
+    mv "${setup_src[0]}" "dist/$filename"
     echo "Setup built!"
 }
 


### PR DESCRIPTION
The v0.14.0b5-research tag build ([run 34208437212](https://github.com/ActivityWatch/activitywatch/actions/runs/34208437212)) failed on exactly the two Windows jobs: #1434's research patcher renames the Inno Setup `OutputBaseFilename` to `activitywatch-research-setup` / `activitywatch-research-tauri-setup` (which worked — the log shows the compiled exe), but `package-all.sh` still ran `mv dist/activitywatch-setup.exe …` → `mv: cannot stat` → `make package` Error 1 on both Qt and Tauri. All non-Windows jobs passed.

Fix: glob the single produced `dist/activitywatch*-setup.exe` (dist/ is fresh at this point) with a fail-loud assertion that exactly one exists, then move it to the final `$filename`. Works for both editions and stays correct if the patcher's naming evolves.

Escaped the 6.2 research PR-CI leg because that job doesn't exercise Windows packaging — noting that as a follow-up candidate rather than expanding this PR.